### PR TITLE
fix: scale DockSwipe velocity with step count on multi-step switches

### DIFF
--- a/App/SpaceSwitching.swift
+++ b/App/SpaceSwitching.swift
@@ -330,13 +330,16 @@ private func postGesturePair(flagDirection: Int64, phase: Int64,
 /// The "Ended" event tells it the swipe finished with extreme velocity,
 /// which makes the Dock switch spaces instantly without animation.
 ///
-/// - Parameter direction: `-1` for left, `+1` for right.
+/// - Parameters:
+///   - direction: `-1` for left, `+1` for right.
+///   - velocity: Magnitude of the Ended-phase velocity.
 /// - Returns: `true` if both gesture phases were posted successfully.
-func postSwitchGesture(direction: Int) -> Bool {
-    let isRight       = direction > 0
+func postSwitchGesture(direction: Int,
+                       velocity: Double = kInstantSwitchVelocity) -> Bool {
+    let isRight              = direction > 0
     let flagDirection: Int64 = isRight ? 1 : 0
-    let progress      = isRight ? kInstantSwitchProgress : -kInstantSwitchProgress
-    let velocity      = isRight ? kInstantSwitchVelocity : -kInstantSwitchVelocity
+    let progress             = isRight ? kInstantSwitchProgress : -kInstantSwitchProgress
+    let signedVelocity       = isRight ? velocity : -velocity
 
     // Phase 1: Begin the swipe (zero velocity/progress — just a start signal)
     let beganOK = postGesturePair(
@@ -351,7 +354,7 @@ func postSwitchGesture(direction: Int) -> Bool {
         flagDirection: flagDirection,
         phase: kCGSGesturePhaseEnded,
         progress: progress,
-        velocity: velocity
+        velocity: signedVelocity
     )
 
     return beganOK && endedOK
@@ -360,13 +363,16 @@ func postSwitchGesture(direction: Int) -> Bool {
 /// Posts N consecutive space-switch gestures in the given direction.
 ///
 /// Used by auto-follow when the target space is more than one step away.
+/// Velocity is scaled by `steps` so the Dock snaps straight to the target
+/// rather than animating between intermediate spaces on long jumps.
 /// Stops early if any gesture fails (e.g. CGEvent allocation failure).
 ///
 /// - Parameters:
 ///   - direction: `-1` for left, `+1` for right.
 ///   - steps: How many spaces to traverse.
 private func switchNSpaces(direction: Int, steps: Int) {
-    for i in 0..<steps where !postSwitchGesture(direction: direction) {
+    let velocity = kInstantSwitchVelocity * Double(steps)
+    for i in 0..<steps where !postSwitchGesture(direction: direction, velocity: velocity) {
         fputs("Space Rabbit: gesture failed at step \(i + 1)/\(steps)\n", stderr)
         break
     }


### PR DESCRIPTION
 Hi! Really like the app, but noticed an issue with Cmd+Tabbing (and switching directly across many spaces, when building that feature #2 ). Opening this as a tested fix, hopefully you don't mind the unsolicited contribution :)

When the target app is one space away, the switch is instant as expected. But when it's several spaces away, the Dock renders an animated slide between the intermediate spaces. This means the instant switching only works for shorter hops. The limit seems to be around ~4 spaces.

### Before/after

https://github.com/user-attachments/assets/c2ccf920-44be-462b-a867-9310d7de641e

https://github.com/user-attachments/assets/b2d3a470-9b2e-453a-adde-2a647e4b6902

 ### Repro

 1. Place App A on Desktop 1 and App B on Desktop 5-7.
 2. From Desktop 1, Cmd+Tab to B.
 3. Observe the multi-step slide animation between spaces.

 ## Cause

`switchNSpaces` posts `steps` consecutive gesture pairs in a tight loop, each with the base `kInstantSwitchVelocity` (400). This value needs to be higher when switches go across to many spaces, to prevent the Dock from falling back to animating.

 ## Fix

Scale the Ended-phase velocity by `Double(steps)` so the combined gesture sequence stays above the snap threshold for the full distance. Matches the approach used by the inspiration source [InstantSpaceSwitcher](https://github.com/jurplel/InstantSpaceSwitcher).

 - `postSwitchGesture` gains an optional `velocity:` parameter defaulting to `kInstantSwitchVelocity` (no change at existing call sites).
 - `switchNSpaces` computes `kInstantSwitchVelocity * Double(steps)` and passes it to each gesture in the loop.

 No new constants; the existing `kInstantSwitchVelocity` is reused as the per-step base.

 ## Test

 - Cmd+Tab between apps 6+ spaces apart — no intermediate animation.
 - Single-step switches unchanged.