### PR TITLE
feat: support direct "Switch to Desktop N" shortcuts

### DIFF
--- a/App/EventTap.swift
+++ b/App/EventTap.swift
@@ -2,7 +2,8 @@
  * EventTap.swift — Feature 1: Instant space switch via event tap
  *
  * Installs a CGEvent tap at the session level to intercept keyDown
- * events that match the user's "Move left/right a space" shortcut.
+ * events that match the user's "Move left/right a space" or
+ * "Switch to Desktop N" shortcuts.
  *
  * When the shortcut is detected:
  *   1. The original key event is swallowed (returns nil to the tap)
@@ -66,7 +67,25 @@ func eventTapCallback(proxy: CGEventTapProxy, type: CGEventType,
     // Check that exactly the required modifiers are held (no extras).
     // This prevents false positives when e.g. Cmd+Control+Arrow is pressed
     // but we only want Control+Arrow.
-    guard flags.intersection(kRelevantModifiers) == gModMask else {
+    let eventMods = flags.intersection(kRelevantModifiers)
+
+    // Direct "Switch to Desktop N" — jump straight to that desktop.
+    // switchToSpace handles the no-op case when we're already there.
+    for (idx, binding) in gSpaceKeys.enumerated() {
+        guard let binding,
+              keycode == binding.keycode,
+              eventMods == binding.mods else { continue }
+
+        let spaceIDs = getSpaceList().ids
+        guard idx < spaceIDs.count else { return nil }
+
+        switchToSpace(spaceIDs[idx])
+        gLastSpaceSwitchTime = Date()
+        gMenu?.recordSwitch()
+        return nil
+    }
+
+    guard eventMods == gModMask else {
         return passthrough
     }
 

--- a/App/Shortcuts.swift
+++ b/App/Shortcuts.swift
@@ -127,4 +127,15 @@ func loadSpaceSwitchShortcuts() {
     // same modifiers, but if only one side is configured, prefer that one.
     if      !leftMods.isEmpty  { gModMask = leftMods  }
     else if !rightMods.isEmpty { gModMask = rightMods }
+
+    // Hotkeys 118..127 = "Switch to Desktop 1".."Switch to Desktop 10"
+    for i in 0..<10 {
+        var keycode: Int64        = -1
+        var mods:    CGEventFlags = []
+        readHotkey(from: prefs, key: String(118 + i), keycode: &keycode, mods: &mods)
+        // Require at least one modifier to avoid intercepting bare number keys
+        if keycode != -1, !mods.isEmpty {
+            gSpaceKeys[i] = (keycode, mods)
+        }
+    }
 }

--- a/App/State.swift
+++ b/App/State.swift
@@ -75,6 +75,10 @@ var gKeyRight: Int64 = 124
 /// Both left and right shortcuts share the same modifier mask.
 var gModMask: CGEventFlags = .maskControl
 
+/// Per-desktop "Switch to Desktop N" bindings (index 0 = Desktop 1 ... index 9 = Desktop 10).
+/// `nil` means the slot is not bound or disabled in System Settings.
+var gSpaceKeys: [(keycode: Int64, mods: CGEventFlags)?] = Array(repeating: nil, count: 10)
+
 // MARK: - UI References
 
 /// The menu bar status item instance (created at startup in `main.swift`).


### PR DESCRIPTION
A common and useful workflow in WMs like yabai or aerospace is jumping directly to a specific desktop (e.g. Alt+1, Alt+2, Alt+N). This is supported by [InstantSpaceSwitcher](https://github.com/jurplel/InstantSpaceSwitcher) but not currently by Space Rabbit as only the "Move left/right a space" shortcuts are intercepted, so the "Switch to Desktop N" shortcuts still animate via the native macOS path.

This PR intercepts/reads those shortcuts (hotkey IDs 118..127) as well as the existing ones, and dispatches to the existing `switchToSpace` when one fires.

Best experienced together with #1  as without it, direct jumps of 5+ spaces still animate through intermediates. Works independently as well though.

 ## Notes

 - Each binding carries its own modifier mask rather than reusing `gModMask`, since the direct shortcuts can be configured with different modifiers than left/right.
 - Bindings with no modifiers are ignored, so a half-configured shortcut doesn't start intercepting bare number keys.
 - Shortcut *i* maps to the *i*-th space on the active display — matches macOS's per-display Switch-to-Desktop-N behavior.

## Test

- Bind Alt+1/2/3 to Switch to Desktop 1/2/3 in System Settings; each shortcut jumps
straight to that desktop, native animation suppressed.
- Unbound slots are ignored.
- Multi-monitor: each shortcut resolves on the display that currently has the active
space.