### PR TITLE
fix: enforce macOS deployment target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ SWIFTFLAGS ?= -O
 
 MACOS_MIN                = 15.0
 MACOSX_DEPLOYMENT_TARGET = $(MACOS_MIN)
+SWIFT_TARGET             ?= $(shell uname -m)-apple-macosx$(MACOS_MIN)
 LDFLAGS     = -framework CoreGraphics -framework CoreFoundation \
               -framework ApplicationServices -framework AppKit \
               -framework ServiceManagement
@@ -25,12 +26,20 @@ APPLE_APP_PASSWORD ?=
 
 VERSION   ?= $(shell git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')
 
-.PHONY: build icon app app-dev dmg notarize release clean
+.PHONY: build icon app app-dev dmg notarize release clean verify-macos-min
 
-build: $(BIN)
+build: $(BIN) verify-macos-min
 
-$(BIN): $(SRCS)
-	$(SWIFTC) $(SWIFTFLAGS) -o $@ $(SRCS) $(LDFLAGS)
+$(BIN): $(SRCS) Makefile
+	$(SWIFTC) $(SWIFTFLAGS) -target $(SWIFT_TARGET) -o $@ $(SRCS) $(LDFLAGS)
+
+verify-macos-min: $(BIN)
+	@actual_min="$$(otool -l $(BIN) | awk '/LC_BUILD_VERSION/ { found = 1; next } found && /minos/ { print $$2; exit }')"; \
+	if [ "$$actual_min" != "$(MACOS_MIN)" ]; then \
+	  echo "==> ERROR: $(BIN) was built for macOS $$actual_min, expected $(MACOS_MIN)."; \
+	  echo "==> Check MACOS_MIN/SWIFT_TARGET and rebuild before packaging."; \
+	  exit 1; \
+	fi
 
 icon: $(ICNS)
 
@@ -40,7 +49,7 @@ $(ICNS): Icon/CreateIcon.swift
 	@mv AppIcon.icns $(ICNS)
 	@echo "==> Generated $(ICNS)"
 
-app: $(BIN) $(ICNS)
+app: build $(ICNS)
 	@echo "==> Building $(APP_BUNDLE)..."
 	@rm -rf $(Q_BUNDLE)
 	@mkdir -p $(Q_BUNDLE)/Contents/MacOS

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ make app
 3. Finally, it needs to be packaged and notarized into `Space-Rabbit.dmg` as such:
 
 ```bash
-make release
+make clean release
 ```
 
 4. When the final DMG has been packaged and notarized, simply draft a new release on [space-rabbit/releases](https://github.com/Tahul/space-rabbit/releases) and upload `Space-Rabbit.dmg`.


### PR DESCRIPTION
## Summary

- pass an explicit Swift target using the configured `MACOS_MIN`
- relink `spacerabbit` when the Makefile changes, so deployment-target changes cannot reuse a stale binary
- add a build-time check that fails if the executable's Mach-O minimum macOS version does not match `MACOS_MIN`
- recommend `make clean release` for maintainer release builds

## Root cause

The v1.4.1 DMG's app bundle advertises `LSMinimumSystemVersion = 15.0`, but the embedded executable was built with `LC_BUILD_VERSION minos 26.0`. Finder rejects that binary on macOS 15 before launch.

The source Makefile already sets `MACOS_MIN = 15.0`, but the `spacerabbit` target only depended on `App/*.swift`. If a previous executable was already present, a release build could update the generated `Info.plist` while packaging a stale binary compiled with a higher deployment target.

I checked the public GitHub Actions history and did not find a release-build workflow for v1.4.1: the repository only has the dynamic GitHub Pages deployment workflow, and there were no Actions runs on June 13-14, 2026. The published asset metadata shows `Space-Rabbit.dmg` was uploaded directly by `valeriansaliou` with digest `sha256:3e86a410554a1a4eb5b9035f90a73b24c4f1afffcb9a3163c6715bed236ddfe8`.

I could reproduce the published mismatch by creating a preexisting `spacerabbit` binary with `minos 26.0`, checking out v1.4.1, and running `make app` without cleaning: the app bundle had `LSMinimumSystemVersion = 15.0`, but the executable still had `minos 26.0`.

## Validation

- `make clean build`
- `otool -l spacerabbit | sed -n '/LC_BUILD_VERSION/,+8p'` reports `minos 15.0`
- `make app` produces `Space Rabbit.app` with both `LSMinimumSystemVersion = 15.0` and executable `minos 15.0`
- stale-artifact reproduction: v1.4.1 `make app` without cleaning can package an existing `minos 26.0` executable while writing `LSMinimumSystemVersion = 15.0`
- negative check: `SWIFT_TARGET=arm64-apple-macosx26.0 make build` fails with `spacerabbit was built for macOS 26.0, expected 15.0`
