### PR TITLE
Add option to hide the menu bar icon

### DIFF
--- a/App/MenuBar.swift
+++ b/App/MenuBar.swift
@@ -122,11 +122,12 @@ final class SwoopMenu: NSObject {
         // the user has toggled anything)
         let defaults = UserDefaults.standard
         defaults.register(defaults: [
-            Defaults.enabled:       true,
-            Defaults.instantSwitch: true,
-            Defaults.autoFollow:    true,
-            Defaults.switchSpeed:   1.0,
-            Defaults.switchCount:   0,
+            Defaults.enabled:         true,
+            Defaults.instantSwitch:   true,
+            Defaults.autoFollow:      true,
+            Defaults.switchSpeed:     1.0,
+            Defaults.switchCount:     0,
+            Defaults.showMenuBarIcon: true,
         ])
 
         // Load persisted state from UserDefaults into the global variables
@@ -140,6 +141,7 @@ final class SwoopMenu: NSObject {
 
         // Create the status bar item (variable width to accommodate the icon)
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        statusItem.isVisible = defaults.bool(forKey: Defaults.showMenuBarIcon)
 
         // Create the main menu items with keyboard shortcuts
         instantSwitchItem = NSMenuItem(title: "Instant Space Switch \u{2303}\u{2194}",
@@ -335,6 +337,20 @@ final class SwoopMenu: NSObject {
     }
 
     // MARK: - Menu Bar Icon
+
+    /// Whether the rabbit icon is currently shown in the menu bar.
+    var isMenuBarIconVisible: Bool { statusItem.isVisible }
+
+    /// Shows or hides the menu bar icon and persists the preference.
+    ///
+    /// When hidden, Space Rabbit keeps running; Preferences can be opened
+    /// again by launching the app from Spotlight or the Applications folder.
+    ///
+    /// - Parameter visible: `true` to show the icon, `false` to hide it.
+    func setMenuBarIconVisible(_ visible: Bool) {
+        statusItem.isVisible = visible
+        UserDefaults.standard.set(visible, forKey: Defaults.showMenuBarIcon)
+    }
 
     /// Updates the menu bar icon appearance based on the enabled state.
     ///

--- a/App/Settings.swift
+++ b/App/Settings.swift
@@ -7,7 +7,7 @@
  *
  *   Auto-Start — Launch at Login toggle (+ warning banner)
  *   Features   — Instant space switch, Auto-follow, Transition speed
- *   Advanced   — Dock instant-hide
+ *   Advanced   — Dock instant-hide, menu bar icon visibility
  *   Updates    — Manual update check + manual-update notice
  *   About      — App icon, version, authors
  *
@@ -943,7 +943,7 @@ final class FeaturesPaneController: SettingsPaneViewController {
 
 // MARK: - Advanced Pane
 
-/// The "Advanced" pane: Dock instant-hide toggle.
+/// The "Advanced" pane: Dock instant-hide and menu bar icon visibility.
 ///
 /// macOS supports a hidden preference `autohide-time-modifier` on com.apple.dock
 /// that controls the Dock show/hide animation speed. Setting it to 0.0 makes the
@@ -956,6 +956,7 @@ final class AdvancedPaneController: SettingsPaneViewController {
     override var paneTitle: String { SettingsPane.advanced.title }
 
     private var instantDockHideControl: NSSwitch!
+    private var showMenuBarIconControl: NSSwitch!
     private var dockResetDivider:       NSView!
     private var dockResetRow:           NSView!
 
@@ -976,6 +977,16 @@ final class AdvancedPaneController: SettingsPaneViewController {
             isDockInstantHideEnabled(),
             #selector(toggleDockInstantHide)
         )
+
+        let menuBarSubtitle = NSTextField(wrappingLabelWithString:
+            "When hidden, launch Space Rabbit again to open Preferences.")
+        menuBarSubtitle.font                    = .systemFont(ofSize: 11)
+        menuBarSubtitle.textColor               = .secondaryLabelColor
+        menuBarSubtitle.preferredMaxLayoutWidth = 240
+
+        let menuBarVisible = UserDefaults.standard.object(forKey: Defaults.showMenuBarIcon) as? Bool
+            ?? true
+        showMenuBarIconControl = makeSwitch(menuBarVisible, #selector(toggleShowMenuBarIcon))
 
         // "Reset to system default" link button (only visible when overridden)
         let resetBtn = LinkButton(title: "", target: self, action: #selector(resetDockToDefault))
@@ -1013,7 +1024,7 @@ final class AdvancedPaneController: SettingsPaneViewController {
         dockResetDivider.isHidden = true
         dockResetRow.isHidden     = true
 
-        let group = groupBox([
+        let dockGroup = groupBox([
             settingsRow(
                 label:    "Instant Dock hide",
                 control:  instantDockHideControl,
@@ -1022,12 +1033,22 @@ final class AdvancedPaneController: SettingsPaneViewController {
             dockResetDivider,
             dockResetRow,
         ])
-        return [group]
+        let menuBarGroup = groupBox([
+            settingsRow(
+                label:    "Show menu bar icon",
+                control:  showMenuBarIconControl,
+                subtitle: menuBarSubtitle
+            ),
+        ])
+        return [dockGroup, menuBarGroup]
     }
 
     override func viewWillAppear() {
         super.viewWillAppear()
         instantDockHideControl.state = isDockInstantHideEnabled() ? .on : .off
+        let menuBarVisible = gMenu?.isMenuBarIconVisible
+            ?? (UserDefaults.standard.object(forKey: Defaults.showMenuBarIcon) as? Bool ?? true)
+        showMenuBarIconControl.state = menuBarVisible ? .on : .off
         updateDockResetLink()
     }
 
@@ -1089,6 +1110,11 @@ final class AdvancedPaneController: SettingsPaneViewController {
         instantDockHideControl.state = .off
         updateDockResetLink()
         promptDockRestart()
+    }
+
+    @objc private func toggleShowMenuBarIcon() {
+        let visible = showMenuBarIconControl.state == .on
+        gMenu?.setMenuBarIconVisible(visible)
     }
 }
 

--- a/App/State.swift
+++ b/App/State.swift
@@ -100,11 +100,14 @@ var gMenu: SwoopMenu?
 /// All keys use the `"spacerabbit."` prefix to namespace them within
 /// the app's UserDefaults domain.
 enum Defaults {
-    static let enabled       = "spacerabbit.enabled"
-    static let instantSwitch = "spacerabbit.instantSwitch"
-    static let autoFollow    = "spacerabbit.autoFollow"
-    static let switchSpeed   = "spacerabbit.switchSpeed"
-    static let switchCount   = "spacerabbit.switchCount"
+    static let enabled         = "spacerabbit.enabled"
+    static let instantSwitch   = "spacerabbit.instantSwitch"
+    static let autoFollow      = "spacerabbit.autoFollow"
+    static let switchSpeed     = "spacerabbit.switchSpeed"
+    static let switchCount     = "spacerabbit.switchCount"
+    /// When `false`, the rabbit icon is removed from the menu bar.
+    /// Preferences remain reachable by launching Space Rabbit again.
+    static let showMenuBarIcon = "spacerabbit.showMenuBarIcon"
 }
 
 // MARK: - Persistence

--- a/App/main.swift
+++ b/App/main.swift
@@ -16,6 +16,35 @@
 import AppKit
 import CoreGraphics
 import ApplicationServices
+import Carbon.HIToolbox
+
+// MARK: - Application Delegate
+
+/// Handles reopen (user launches Space Rabbit while it is already running).
+///
+/// Needed when the menu bar icon is hidden: there is otherwise no UI entry
+/// point. Opening the app again from Spotlight or Finder surfaces Preferences.
+final class AppDelegate: NSObject, NSApplicationDelegate {
+
+    func applicationShouldHandleReopen(_ sender: NSApplication,
+                                       hasVisibleWindows flag: Bool) -> Bool {
+        SettingsWindowController.shared.show(pane: .advanced)
+        return false
+    }
+}
+
+// MARK: - Login Item Detection
+
+/// Returns `true` when this process was started as a login item.
+///
+/// Used so a hidden menu bar icon does not pop Preferences at every login,
+/// while a manual launch of the app still opens Preferences as the recovery path.
+private func isLaunchedAsLoginItem() -> Bool {
+    guard let event = NSAppleEventManager.shared().currentAppleEvent else { return false }
+    guard event.eventID == AEEventID(kAEOpenApplication) else { return false }
+    guard let propData = event.paramDescriptor(forKeyword: keyAEPropData) else { return false }
+    return propData.enumCodeValue == AEKeyword(keyAELaunchedAsLogInItem)
+}
 
 // MARK: - Application Setup
 
@@ -24,6 +53,8 @@ import ApplicationServices
 UserDefaults.standard.removeObject(forKey: "AppleAccentColor")
 
 let app = NSApplication.shared
+let appDelegate = AppDelegate()
+app.delegate = appDelegate
 app.setActivationPolicy(.accessory)
 
 // MARK: - Accessibility Permission Check
@@ -48,6 +79,14 @@ loadSpaceSwitchShortcuts()
 // Create the menu bar status item and load persisted preferences
 // (switch count, feature toggles, etc.) from UserDefaults
 gMenu = SwoopMenu()
+
+// If the menu bar icon is hidden and the user launched the app manually
+// (not as a login item), open Preferences so they still have a way in.
+if gMenu?.isMenuBarIconVisible == false, !isLaunchedAsLoginItem() {
+    DispatchQueue.main.async {
+        SettingsWindowController.shared.show(pane: .advanced)
+    }
+}
 
 // Check for updates 5 seconds after launch, giving the app time to
 // settle before making a network request. Launch-only by design: no


### PR DESCRIPTION
## Summary
- Adds a **Show menu bar icon** toggle under Preferences → Advanced (default on).
- When hidden, Space Rabbit keeps running in the background with no top-bar icon.
- Recovery path: launch Space Rabbit again from Spotlight / Applications to open Preferences (login-item launches stay quiet).

## Test plan
- [ ] Build with `make app` / `make app-dev`
- [ ] Confirm the rabbit icon still appears by default
- [ ] Turn off **Show menu bar icon** in Advanced — icon disappears; Preferences window stays open so you can turn it back on
- [ ] Quit and relaunch from Spotlight with the icon hidden — Preferences opens on Advanced
- [ ] With launch-at-login enabled and icon hidden, log out/in (or simulate login-item launch) — app starts without opening Preferences
- [ ] With the app already running and icon hidden, open Space Rabbit again — Preferences opens
- [ ] Turn the toggle back on — icon returns to the menu bar


Made with [Cursor](https://cursor.com)