### PR TITLE
Preserve native Space moves while dragging windows

### DIFF
--- a/App/EventTap.swift
+++ b/App/EventTap.swift
@@ -68,6 +68,15 @@ func eventTapCallback(proxy: CGEventTapProxy, type: CGEventType,
         return passthrough
     }
 
+    // Window managers such as Rectangle Pro and Raycast move a window to an
+    // adjacent Space by holding its title bar while invoking the system Space
+    // shortcut. Replacing that shortcut with a DockSwipe switches Spaces but
+    // leaves the held window behind, so preserve macOS's native handling while
+    // the primary mouse button is down.
+    if CGEventSource.buttonState(.combinedSessionState, button: .left) {
+        return passthrough
+    }
+
     let flags   = event.flags
     let keycode = event.getIntegerValueField(.keyboardEventKeycode)
 


### PR DESCRIPTION
## Summary

- pass Space-switch shortcuts through to macOS while the primary mouse button is held
- preserve compatibility with Rectangle Pro, Raycast, and other window managers that move windows by holding the title bar while invoking the native Space shortcut
- keep Space Rabbit's instant DockSwipe behavior unchanged for normal keyboard-driven switching

Space Rabbit currently swallows the native shortcut and posts a DockSwipe instead. During a window-manager move, that switches Spaces but leaves the held window behind. Allowing native handling only while the primary button is down preserves both workflows; moving a window uses the native animated transition, while ordinary switches remain instant.

Rectangle Pro documents this title-bar-hold mechanism: https://rectangleapp.com/pro/docs/keyboard-shortcuts/#nextprevious-space

## Verification

- `make build`
- `swift build`
- `SIGN_ID=- make app`
- `codesign --verify --deep --strict --verbose=2 "Space Rabbit.app"`
- verified deployment target remains macOS 15.0