### PR TITLE
fix: revive event taps after system sleep or screen lock

### DIFF
--- a/App/EventTap.swift
+++ b/App/EventTap.swift
@@ -54,6 +54,100 @@ private var gMissionControlActiveKeycode: Int64?
 /// DockSwipe of its own — Dock runs its animated transition internally.
 private let kMissionControlKeycode: Int64 = 160
 
+// MARK: - Primary Tap Lifecycle
+
+/// Creates the session-level keyDown tap, attaches it to the main run loop
+/// and enables it. Stores the tap and its source in `gTap` / `gTapSource`.
+///
+/// Called once at startup (main.swift, where a failure is fatal) and again
+/// by `reviveKeyboardTapsIfNeeded()` when the tap has to be rebuilt.
+///
+/// - Returns: `false` when the tap could not be created (e.g. Accessibility
+///   permission missing or revoked).
+func installEventTap() -> Bool {
+    let keyDownMask = CGEventMask(1 << CGEventType.keyDown.rawValue)
+    guard let primary = makeKeyboardTap(mask: keyDownMask) else { return false }
+
+    CGEvent.tapEnable(tap: primary.tap, enable: true)
+    gTap       = primary.tap
+    gTapSource = primary.source
+    return true
+}
+
+/// Brings dead keyboard taps back to life after system sleep or screen lock.
+///
+/// The self-re-enable in `eventTapCallback` only works while the callback is
+/// still being invoked: macOS delivers `tapDisabledByTimeout` /
+/// `tapDisabledByUserInput` *through the tap itself*. A tap disabled — or its
+/// Mach port invalidated outright — while the process is suspended around
+/// sleep or lock never receives that notice and stays dead until relaunch.
+/// Runs from the wake/unlock observers and the periodic flush timer in
+/// main.swift; a healthy tap set makes this a cheap no-op.
+func reviveKeyboardTapsIfNeeded() {
+    // Primary keyDown tap: always-on, so any disable found here is a system
+    // disable that the callback never got to see.
+    if let tap = gTap, CFMachPortIsValid(tap) {
+        if !CGEvent.tapIsEnabled(tap: tap) {
+            fputs("Space Rabbit: keyboard tap was disabled — re-enabling after wake/unlock\n", stderr)
+            resetKeyTracking()
+            CGEvent.tapEnable(tap: tap, enable: true)
+        }
+    } else {
+        // Port invalidated — its run loop source died with it; rebuild.
+        fputs("Space Rabbit: keyboard tap port died — rebuilding after wake/unlock\n", stderr)
+        resetKeyTracking()
+        if let source = gTapSource {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+        }
+        gTap       = nil
+        gTapSource = nil
+        if !installEventTap() {
+            fputs("Space Rabbit: failed to rebuild keyboard tap\n", stderr)
+        }
+    }
+
+    // Auxiliary taps. Rebuild both when either port died; otherwise refresh
+    // the cached enabled flags from reality — a system disable during the
+    // suspension leaves them stale, and setKeyboardTap only pushes state to
+    // the window server on a flag change, so a stale flag pins the tap dead.
+    let claimedPortDied  = gClaimedKeyTap.map { !CFMachPortIsValid($0) } ?? false
+    let modifierPortDied = gModifierKeyTap.map { !CFMachPortIsValid($0) } ?? false
+
+    if claimedPortDied || modifierPortDied {
+        fputs("Space Rabbit: auxiliary keyboard tap port died — rebuilding after wake/unlock\n", stderr)
+        resetKeyTracking()
+        for tap in [gClaimedKeyTap, gModifierKeyTap] {
+            if let tap, CFMachPortIsValid(tap) { CGEvent.tapEnable(tap: tap, enable: false) }
+        }
+        for source in [gClaimedKeyTapSource, gModifierKeyTapSource] {
+            if let source { CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes) }
+        }
+        gClaimedKeyTap         = nil
+        gClaimedKeyTapSource   = nil
+        gClaimedKeyTapEnabled  = false
+        gModifierKeyTap        = nil
+        gModifierKeyTapSource  = nil
+        gModifierKeyTapEnabled = false
+        installAuxiliaryKeyboardTaps()
+    } else {
+        var cacheWasStale = false
+        if let tap = gClaimedKeyTap {
+            let actual = CGEvent.tapIsEnabled(tap: tap)
+            if actual != gClaimedKeyTapEnabled { gClaimedKeyTapEnabled = actual; cacheWasStale = true }
+        }
+        if let tap = gModifierKeyTap {
+            let actual = CGEvent.tapIsEnabled(tap: tap)
+            if actual != gModifierKeyTapEnabled { gModifierKeyTapEnabled = actual; cacheWasStale = true }
+        }
+        if cacheWasStale {
+            // Any claim from before the suspension is stale; drop it so the
+            // sync below resolves each tap to the state it should be in now.
+            resetKeyTracking()
+            syncKeyboardAuxiliaryTaps()
+        }
+    }
+}
+
 // MARK: - Auxiliary Tap Lifecycle
 
 /// Creates the two on-demand companions to `gTap`, both left disabled.

--- a/App/State.swift
+++ b/App/State.swift
@@ -15,9 +15,11 @@ import Foundation
 
 // MARK: - Event Tap State
 
-/// The active CGEvent tap (installed at startup, never replaced).
+/// The active CGEvent tap (installed at startup via `installEventTap()`).
 /// Used by the event tap callback to intercept space-switch shortcuts,
-/// and re-enabled automatically if macOS disables it.
+/// and re-enabled automatically if macOS disables it. Rebuilt by
+/// `reviveKeyboardTapsIfNeeded()` when its Mach port dies across system
+/// sleep or screen lock.
 ///
 /// It listens for `keyDown` only — the sole event form that can *match* a
 /// shortcut. The other three keyboard event forms the feature needs are split
@@ -28,6 +30,10 @@ import Foundation
 /// typing on macOS 26: `keyUp` is exactly as frequent as `keyDown`, and was
 /// half of this tap's wakeups.
 var gTap: CFMachPort?
+
+/// Run loop source backing `gTap`, kept so the source can be removed when
+/// the tap is rebuilt after wake (and on termination).
+var gTapSource: CFRunLoopSource?
 
 /// Tap for `keyUp` and `systemDefined`, enabled only while a key press has
 /// actually been claimed or a bare-Fn candidate is in progress

--- a/App/SwipeIntercept.swift
+++ b/App/SwipeIntercept.swift
@@ -149,6 +149,68 @@ func updateSwipeTap() {
     }
 }
 
+/// Brings dead gesture taps back to life after system sleep or screen lock.
+///
+/// Same failure mode as the keyboard taps (see `reviveKeyboardTapsIfNeeded()`
+/// in EventTap.swift): the self-re-enable in `swipeTapCallback` never runs
+/// when a tap is disabled — or its Mach port invalidated — while the process
+/// is suspended. `updateSwipeTap()` alone can't recover either: it no-ops
+/// while `gSwipeTap` is non-nil, even when that port is dead. Runs from the
+/// wake/unlock observers and the periodic flush timer in main.swift.
+func reviveSwipeTapIfNeeded() {
+    guard let tap = gSwipeTap else { return }  // features off — nothing installed
+
+    let envelopePortDied = gGestureEnvelopeTap.map { !CFMachPortIsValid($0) } ?? false
+
+    if !CFMachPortIsValid(tap) || envelopePortDied {
+        // A port was invalidated — its run loop source died with it. Clear
+        // out the corpses so updateSwipeTap() sees "not installed" and
+        // rebuilds the pair for the still-enabled features.
+        fputs("Space Rabbit: gesture tap port died — rebuilding after wake/unlock\n", stderr)
+        for deadTap in [gSwipeTap, gGestureEnvelopeTap] {
+            if let deadTap, CFMachPortIsValid(deadTap) { CGEvent.tapEnable(tap: deadTap, enable: false) }
+        }
+        for source in [gSwipeTapSource, gGestureEnvelopeTapSource] {
+            if let source { CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes) }
+        }
+        gSwipeTap                  = nil
+        gSwipeTapSource            = nil
+        gGestureEnvelopeTap        = nil
+        gGestureEnvelopeTapSource  = nil
+        gGestureEnvelopeTapEnabled = false
+        resetSwipeIntercept()
+        updateSwipeTap()
+        return
+    }
+
+    // Ports valid — recover from a system disable delivered while suspended.
+    // The DockControl tap is enabled for as long as it is installed, so any
+    // disable found here is one the callback never saw.
+    if !CGEvent.tapIsEnabled(tap: tap) {
+        fputs("Space Rabbit: gesture tap was disabled — re-enabling after wake/unlock\n", stderr)
+        resetSwipeIntercept()
+        CGEvent.tapEnable(tap: tap, enable: true)
+        if let envelopeTap = gGestureEnvelopeTap {
+            gGestureEnvelopeTapEnabled = CGEvent.tapIsEnabled(tap: envelopeTap)
+            syncGestureEnvelopeTap()
+        }
+        return
+    }
+
+    // The envelope tap's cached flag can also go stale on its own (it is the
+    // only gesture tap enabled mid-gesture, exactly when a suspension would
+    // catch it). Refresh the cache and let the sync settle it — nothing is
+    // tracked after the reset, so a stuck-on tap gets switched off.
+    if let envelopeTap = gGestureEnvelopeTap {
+        let actual = CGEvent.tapIsEnabled(tap: envelopeTap)
+        if actual != gGestureEnvelopeTapEnabled {
+            gGestureEnvelopeTapEnabled = actual
+            resetSwipeIntercept()
+            syncGestureEnvelopeTap()
+        }
+    }
+}
+
 /// Creates one session tap listening for a single private gesture event type.
 ///
 /// - Parameter subtype: `kCGSEventGesture` or `kCGSEventDockControl` — which

--- a/App/main.swift
+++ b/App/main.swift
@@ -109,9 +109,13 @@ checkForUpdatesAutomatically()
 // Persist the switch count to disk every 5 minutes.
 // This batching reduces disk I/O compared to writing on every switch.
 // The count is also flushed on termination (see cleanup section below).
+// The timer doubles as a periodic tap health check — a safety net for any
+// tap death the wake/unlock observers below don't catch.
 let flushInterval: TimeInterval = 300
 Timer.scheduledTimer(withTimeInterval: flushInterval, repeats: true) { _ in
     flushSwitchCount()
+    reviveKeyboardTapsIfNeeded()
+    reviveSwipeTapIfNeeded()
 }
 
 // MARK: - Event Tap Installation
@@ -125,29 +129,10 @@ Timer.scheduledTimer(withTimeInterval: flushInterval, repeats: true) { _ in
 // just below, each enabled only for the narrow window in which it can matter.
 // See `gTap` in State.swift for why.
 
-let eventMask = CGEventMask(1 << CGEventType.keyDown.rawValue)
-
-gTap = CGEvent.tapCreate(
-    tap: .cgSessionEventTap,
-    place: .headInsertEventTap,
-    options: .defaultTap,
-    eventsOfInterest: eventMask,
-    callback: eventTapCallback,
-    userInfo: nil
-)
-
-guard let tap = gTap else {
+guard installEventTap() else {
     fputs("Space Rabbit: failed to create event tap\n", stderr)
     exit(1)
 }
-
-guard let runLoopSource = CFMachPortCreateRunLoopSource(nil, tap, 0) else {
-    fputs("Space Rabbit: failed to create run loop source\n", stderr)
-    exit(1)
-}
-
-CFRunLoopAddSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
-CGEvent.tapEnable(tap: tap, enable: true)
 
 // The keyUp/systemDefined and flagsChanged companions to the tap above. Both
 // are created disabled and switched on only while they can matter. Failure is
@@ -217,6 +202,36 @@ NSWorkspace.shared.notificationCenter.addObserver(
     loadSpaceSwitchShortcuts()
 }
 
+// MARK: - Tap Revival After Sleep/Wake
+//
+// macOS can disable the event taps — or invalidate their Mach ports —
+// while the process is suspended around system sleep or screen lock. The
+// disable notice is delivered through the tap callbacks themselves, so a
+// tap that dies during a suspension never gets the chance to self-heal
+// (see reviveKeyboardTapsIfNeeded in EventTap.swift). Check tap health on
+// every wake and unlock, and rebuild whatever died.
+
+NSWorkspace.shared.notificationCenter.addObserver(
+    forName: NSWorkspace.didWakeNotification,
+    object: nil, queue: .main
+) { _ in
+    reviveKeyboardTapsIfNeeded()
+    reviveSwipeTapIfNeeded()
+}
+
+// Screen unlock arrives via the distributed notification center, not
+// NSWorkspace. It fires after lock-screen sessions with no full sleep
+// (where didWakeNotification never comes) and doubles as a second, later
+// chance after wake — the window server is guaranteed up again once the
+// user has unlocked.
+DistributedNotificationCenter.default().addObserver(
+    forName: Notification.Name("com.apple.screenIsUnlocked"),
+    object: nil, queue: .main
+) { _ in
+    reviveKeyboardTapsIfNeeded()
+    reviveSwipeTapIfNeeded()
+}
+
 // MARK: - Cleanup on Exit
 //
 // Flush stats to disk and tear down the event tap when the app terminates.
@@ -229,8 +244,10 @@ NotificationCenter.default.addObserver(
 ) { _ in
     flushSwitchCount()
     NSWorkspace.shared.notificationCenter.removeObserver(observer)
-    CGEvent.tapEnable(tap: tap, enable: false)
-    CFRunLoopRemoveSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
+    if let tap = gTap { CGEvent.tapEnable(tap: tap, enable: false) }
+    if let source = gTapSource {
+        CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+    }
     if let claimedKeyTap = gClaimedKeyTap { CGEvent.tapEnable(tap: claimedKeyTap, enable: false) }
     if let modifierKeyTap = gModifierKeyTap { CGEvent.tapEnable(tap: modifierKeyTap, enable: false) }
     if let swipeTap = gSwipeTap { CGEvent.tapEnable(tap: swipeTap, enable: false) }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,12 +34,13 @@ Exact initialization order — getting this wrong causes subtle bugs:
 5. `gMenu = SwoopMenu()` — creates status item (hidden via `statusItem.isVisible` if so configured), loads persisted state from UserDefaults into globals
 6. `checkForUpdatesAutomatically()` — owns its own 5-second delay, and applies it only when it is actually going to make a network request (a throttled launch restores the update banner from UserDefaults immediately). Must run after step 5, which creates `gMenu`, the banner's host
 7. `Timer` for `flushSwitchCount()` — every 300 seconds
-8. **Event tap creation** — `gTap` listens for `keyDown` only, then `CFMachPortCreateRunLoopSource` → `CFRunLoopAddSource`. `installAuxiliaryKeyboardTaps()` immediately adds the two on-demand companions carrying the other three event forms the cycle shortcut (including bare Fn) and the system Space bindings need — see "Three keyboard taps" under Feature 1. Failure of the primary tap is fatal; failure of an auxiliary one is logged and tolerated
+8. **Event tap creation** — `installEventTap()` (EventTap.swift) creates `gTap` (listens for `keyDown` only, source stored in `gTapSource`). `installAuxiliaryKeyboardTaps()` immediately adds the two on-demand companions carrying the other three event forms the cycle shortcut (including bare Fn) and the system Space bindings need — see "Three keyboard taps" under Feature 1. Failure of the primary tap is fatal; failure of an auxiliary one is logged and tolerated
 9. **Gesture-intercept tap** — `updateSwipeTap()` installs the shared tap pair if either persisted gesture toggle is on (must run after step 5, which loads the toggles; creation failure is non-fatal, unlike step 8)
 10. **SwoopObserver registration** — `didActivateApplicationNotification` + `activeSpaceDidChangeNotification`
-11. **Cleanup handler** — `willTerminateNotification`: flush stats, remove observer, disable both taps
-12. **Signal handlers** — SIGINT/SIGTERM → `NSApp.terminate`
-13. `app.run()` — enter run loop
+11. **Tap revival observers** — `NSWorkspace.didWakeNotification` + distributed `com.apple.screenIsUnlocked` → `reviveKeyboardTapsIfNeeded()` + `reviveSwipeTapIfNeeded()` (see "Event tap lifetime" under Feature 1); the step 7 timer runs the same checks as a safety net
+12. **Cleanup handler** — `willTerminateNotification`: flush stats, remove observer, disable both taps
+13. **Signal handlers** — SIGINT/SIGTERM → `NSApp.terminate`
+14. `app.run()` — enter run loop
 
 ## Core features
 
@@ -53,7 +54,7 @@ A `CGEvent` tap at `.cgSessionEventTap` / `.headInsertEventTap` listens for `key
 3. The Dock handles the gesture at the selected speed (with no animation at
    the Instant tick).
 
-The tap is re-enabled on `tapDisabledByTimeout` / `tapDisabledByUserInput` to stay alive.
+**Event tap lifetime:** the tap is re-enabled on `tapDisabledByTimeout` / `tapDisabledByUserInput` to stay alive — but those notices arrive *through the tap callback itself*, so a tap disabled (or its Mach port invalidated) while the process is suspended around system sleep or screen lock never self-heals. `reviveKeyboardTapsIfNeeded()` (EventTap.swift) and `reviveSwipeTapIfNeeded()` (SwipeIntercept.swift) cover that hole for all five taps: re-enable a valid-but-disabled tap, rebuild on an invalidated Mach port, and refresh the cached `g*TapEnabled` flags of the on-demand taps (a stale cache pins them dead, because the sync helpers only push state on a flag change). They run on `NSWorkspace.didWakeNotification`, on the distributed `com.apple.screenIsUnlocked` notification, and from the 300 s flush timer as a safety net; each revival logs a diagnostic line to stderr.
 
 **Three keyboard taps.** The feature needs four event forms, but only `keyDown`
 can ever *match* a shortcut; the other three exist to close out a press that


### PR DESCRIPTION
Fixes #16

## Problem

After the Mac wakes from sleep (or returns from the lock screen), the instant space switch silently degrades to macOS's native animated switch until the app is relaunched.

Every tap's self-heal lives inside its own callback: macOS delivers `tapDisabledByTimeout` / `tapDisabledByUserInput` *through the tap*, where `CGEvent.tapEnable` re-enables ([EventTap.swift#L292](https://github.com/Tahul/space-rabbit/blob/0f67c6e12a229e37ffcb3ade69330dcd7b69d806/App/EventTap.swift#L285-L297), [SwipeIntercept.swift#L339](https://github.com/Tahul/space-rabbit/blob/0f67c6e12a229e37ffcb3ade69330dcd7b69d806/App/SwipeIntercept.swift#L331-L346)). When a tap is disabled — or its Mach port invalidated outright — while the process is suspended around sleep/lock, that notice never arrives, a disabled tap's callback is never invoked again, and the tap stays dead. `updateSwipeTap()` can't recover the gesture taps either: it no-ops while `gSwipeTap` is non-nil, even when that port is dead. The on-demand taps have an extra failure mode: their cached `g*TapEnabled` flags go stale on a system disable, and the sync helpers only push state to the window server on a flag change, so a stale cache pins them dead.

## Fix

- Extract primary-tap installation into `installEventTap()` (EventTap.swift, reusing `makeKeyboardTap`), storing the run loop source in `gTapSource` so the tap can be rebuilt.
- Add `reviveKeyboardTapsIfNeeded()` (EventTap.swift) and `reviveSwipeTapIfNeeded()` (SwipeIntercept.swift) covering all five taps: re-enable a valid-but-disabled tap (`CFMachPortIsValid` + `CGEvent.tapIsEnabled`); on an invalidated port, remove the dead run loop source(s) and rebuild (the gesture pair is cleared and handed back to `updateSwipeTap()` so the feature gates stay in one place); refresh the cached enabled flags of the on-demand taps from reality before re-syncing. Stale pre-suspension claims are dropped via the existing reset helpers, per their continuity-break contracts.
- Run both checks on `NSWorkspace.didWakeNotification` and on the distributed `com.apple.screenIsUnlocked` notification (covers lock-screen sessions without full sleep, and is a guaranteed-late second chance once the window server is back up), plus piggybacked on the existing 300 s flush timer as a safety net.
- **Each revival logs a diagnostic line to stderr** (e.g. `Space Rabbit: keyboard tap was disabled — re-enabling after wake/unlock`), so anyone hitting #16 can confirm the mechanism from Console/log output — should help gather the reproduction data requested there.
- The termination cleanup handler now reads `gTap`/`gTapSource` instead of the launch-time constants, which would go stale after a rebuild.
- CLAUDE.md startup sequence and Feature 1 notes updated to match.

## Testing

- `make build` passes (Swift 5 mode, localization check OK).
- Not yet manually verified across a real sleep/wake cycle (the failure is intermittent — see #16 for reproduction context; an external display appears to be a factor). The diagnostic logging is there so affected users can verify the fix fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)