### PR TITLE
fix: invert swipe direction

### DIFF
--- a/App/MenuBar.swift
+++ b/App/MenuBar.swift
@@ -100,6 +100,7 @@ final class SwoopMenu: NSObject {
             Defaults.instantSwitch:    true,
             Defaults.autoFollow:       true,
             Defaults.trackpadSwipe:    false,  // opt-in — swallows a real gesture
+            Defaults.invertSwipe:      false,  // follow the system convention
             Defaults.switchSpeed:      1.0,
             Defaults.switchCount:      0,
             Defaults.showMenuBarIcon:  true,
@@ -111,6 +112,7 @@ final class SwoopMenu: NSObject {
         gInstantSwitchEnabled    = defaults.bool(forKey: Defaults.instantSwitch)
         gAutoFollowEnabled       = defaults.bool(forKey: Defaults.autoFollow)
         gTrackpadSwipeEnabled    = defaults.bool(forKey: Defaults.trackpadSwipe)
+        gSwipeDirectionInverted  = defaults.bool(forKey: Defaults.invertSwipe)
         gSwitchSpeed             = defaults.double(forKey: Defaults.switchSpeed)
         gSwitchCount             = defaults.integer(forKey: Defaults.switchCount)
         gSwitchCountSaved        = gSwitchCount

--- a/App/Resources/de.lproj/Localizable.strings
+++ b/App/Resources/de.lproj/Localizable.strings
@@ -86,6 +86,7 @@
 "settings.features.instantSpaceSwitch" = "Sofortiger Space-Wechsel";
 "settings.features.instantAppSwitch" = "Sofortiger App-Wechsel";
 "settings.features.instantTrackpadSwipe" = "Sofortiges Trackpad-Streichen";
+"settings.features.invertSwipeDirection" = "Streichrichtung umkehren";
 "settings.features.transitionSpeed" = "Übergangsgeschwindigkeit";
 
 /* Transition-speed slider ticks, slowest to fastest. "Normal" is macOS's own

--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -88,6 +88,7 @@
 "settings.features.instantSpaceSwitch" = "Instant Space switch";
 "settings.features.instantAppSwitch" = "Instant App switch";
 "settings.features.instantTrackpadSwipe" = "Instant Trackpad swipe";
+"settings.features.invertSwipeDirection" = "Invert swipe direction";
 "settings.features.transitionSpeed" = "Transition speed";
 
 /* Transition-speed slider ticks, slowest to fastest. "Normal" is macOS's own

--- a/App/Resources/es.lproj/Localizable.strings
+++ b/App/Resources/es.lproj/Localizable.strings
@@ -88,6 +88,7 @@
 "settings.features.instantSpaceSwitch" = "Cambio de espacio instantáneo";
 "settings.features.instantAppSwitch" = "Cambio de app instantáneo";
 "settings.features.instantTrackpadSwipe" = "Deslizamiento instantáneo en el trackpad";
+"settings.features.invertSwipeDirection" = "Invertir la dirección del deslizamiento";
 "settings.features.transitionSpeed" = "Velocidad de transición";
 
 /* Transition-speed slider ticks, slowest to fastest. "Normal" is macOS's own

--- a/App/Resources/fr.lproj/Localizable.strings
+++ b/App/Resources/fr.lproj/Localizable.strings
@@ -90,6 +90,7 @@
 "settings.features.instantSpaceSwitch" = "Changement d’Espace instantané";
 "settings.features.instantAppSwitch" = "Changement d’app instantané";
 "settings.features.instantTrackpadSwipe" = "Balayage instantané du trackpad";
+"settings.features.invertSwipeDirection" = "Inverser le sens du balayage";
 "settings.features.transitionSpeed" = "Vitesse de transition";
 
 /* Transition-speed slider ticks, slowest to fastest. "Normal" is macOS's own

--- a/App/Resources/pt.lproj/Localizable.strings
+++ b/App/Resources/pt.lproj/Localizable.strings
@@ -89,6 +89,7 @@
 "settings.features.instantSpaceSwitch" = "Mudança de espaço instantânea";
 "settings.features.instantAppSwitch" = "Mudança de app instantânea";
 "settings.features.instantTrackpadSwipe" = "Deslize instantâneo no trackpad";
+"settings.features.invertSwipeDirection" = "Inverter a direção do deslize";
 "settings.features.transitionSpeed" = "Velocidade da transição";
 
 /* Transition-speed slider ticks, slowest to fastest. "Normal" is macOS's own

--- a/App/Resources/ru.lproj/Localizable.strings
+++ b/App/Resources/ru.lproj/Localizable.strings
@@ -91,6 +91,7 @@
 "settings.features.instantSpaceSwitch" = "Мгновенное переключение столов";
 "settings.features.instantAppSwitch" = "Мгновенное переключение приложений";
 "settings.features.instantTrackpadSwipe" = "Мгновенное смахивание на трекпаде";
+"settings.features.invertSwipeDirection" = "Инвертировать направление смахивания";
 "settings.features.transitionSpeed" = "Скорость перехода";
 
 /* Transition-speed slider ticks, slowest to fastest. "Normal" is macOS's own

--- a/App/Resources/zh-Hans.lproj/Localizable.strings
+++ b/App/Resources/zh-Hans.lproj/Localizable.strings
@@ -91,6 +91,7 @@
 "settings.features.instantSpaceSwitch" = "即时切换空间";
 "settings.features.instantAppSwitch" = "即时切换应用";
 "settings.features.instantTrackpadSwipe" = "即时触控板轻扫";
+"settings.features.invertSwipeDirection" = "反转轻扫方向";
 "settings.features.transitionSpeed" = "过渡速度";
 
 /* Transition-speed slider ticks, slowest to fastest. "Normal" is macOS's own

--- a/App/Settings.swift
+++ b/App/Settings.swift
@@ -852,6 +852,7 @@ final class FeaturesPaneController: SettingsPaneViewController {
     private var instantSwitchControl:    NSSwitch!
     private var autoFollowControl:       NSSwitch!
     private var trackpadSwipeControl:    NSSwitch!
+    private var invertSwipeControl:      NSSwitch!
     private var speedSlider:             NSSlider!
     private var speedValueLabel:         NSTextField!
     private var speedBoltIcon:           NSImageView!
@@ -860,6 +861,7 @@ final class FeaturesPaneController: SettingsPaneViewController {
         instantSwitchControl    = makeSwitch(gInstantSwitchEnabled,    #selector(toggleInstantSwitch))
         autoFollowControl       = makeSwitch(gAutoFollowEnabled,       #selector(toggleAutoFollow))
         trackpadSwipeControl    = makeSwitch(gTrackpadSwipeEnabled,    #selector(toggleTrackpadSwipe))
+        invertSwipeControl      = makeSwitch(gSwipeDirectionInverted,  #selector(toggleInvertSwipe))
 
         let togglesGroup = groupBox([
             settingsRow(label: L("settings.features.instantSpaceSwitch"),
@@ -870,6 +872,9 @@ final class FeaturesPaneController: SettingsPaneViewController {
             rowDivider(),
             settingsRow(label: L("settings.features.instantTrackpadSwipe"),
                         control: trackpadSwipeControl),
+            rowDivider(),
+            settingsRow(label: L("settings.features.invertSwipeDirection"),
+                        control: invertSwipeControl),
         ])
         let speedGroup = groupBox([
             settingsRow(label: L("settings.features.transitionSpeed"),
@@ -884,8 +889,17 @@ final class FeaturesPaneController: SettingsPaneViewController {
         instantSwitchControl.state    = gInstantSwitchEnabled    ? .on : .off
         autoFollowControl.state       = gAutoFollowEnabled       ? .on : .off
         trackpadSwipeControl.state    = gTrackpadSwipeEnabled    ? .on : .off
+        invertSwipeControl.state      = gSwipeDirectionInverted  ? .on : .off
         speedSlider.doubleValue       = gSwitchSpeed
         updateSpeedDisplay()
+        updateInvertSwipeAvailability()
+    }
+
+    /// The invert toggle only has an effect while Space Rabbit is the one
+    /// handling swipes — dim it when the trackpad feature is off so it does
+    /// not read as a setting that changes macOS's own swipe direction.
+    private func updateInvertSwipeAvailability() {
+        invertSwipeControl.isEnabled = gTrackpadSwipeEnabled
     }
 
     /// Builds the transition-speed control: a 5-tick slider with a trailing
@@ -1027,7 +1041,13 @@ final class FeaturesPaneController: SettingsPaneViewController {
         gTrackpadSwipeEnabled = trackpadSwipeControl.state == .on
         UserDefaults.standard.set(gTrackpadSwipeEnabled, forKey: Defaults.trackpadSwipe)
         updateSwipeTap()
+        updateInvertSwipeAvailability()
         gMenu?.syncMenuItems()
+    }
+
+    @objc private func toggleInvertSwipe() {
+        gSwipeDirectionInverted = invertSwipeControl.state == .on
+        UserDefaults.standard.set(gSwipeDirectionInverted, forKey: Defaults.invertSwipe)
     }
 
     @objc private func speedChanged() {

--- a/App/State.swift
+++ b/App/State.swift
@@ -50,6 +50,18 @@ var gAutoFollowEnabled: Bool = true
 /// purely additive features above. Only effective when `gEnabled` is `true`.
 var gTrackpadSwipeEnabled: Bool = false
 
+/// Whether an intercepted trackpad swipe moves to the space *opposite* the
+/// one it normally would. Only consulted by Feature 3 — the keyboard and
+/// auto-follow paths derive their direction from the target space, not from
+/// a gesture, so there is nothing to invert there.
+///
+/// This is a user preference, not a compatibility shim: the built-in mapping
+/// (see `isRightSwipe`) already tracks macOS's per-release sign convention
+/// and the natural-scrolling setting. It exists for people who simply want
+/// the reverse of the system behavior — and as an escape hatch should a
+/// future macOS flip the sign again before Space Rabbit is updated.
+var gSwipeDirectionInverted: Bool = false
+
 /// Space-switch transition speed as a slider tick position (0.0–1.0 in
 /// steps of 0.25). 1.0 (the end cap) means instant — no animation at all.
 /// 0.0 ("Normal") means macOS's native animation: Space Rabbit posts no
@@ -156,6 +168,8 @@ enum Defaults {
     /// purpose — the feature was renamed to "Instant Trackpad Swipe", and
     /// renaming the key would silently reset the opt-in for existing users.
     static let trackpadSwipe    = "spacerabbit.threeFingerSwipe"
+    /// Reverses the direction an intercepted trackpad swipe moves in.
+    static let invertSwipe      = "spacerabbit.invertSwipeDirection"
     static let switchSpeed      = "spacerabbit.switchSpeed"
     static let switchCount      = "spacerabbit.switchCount"
     /// When `false`, the rabbit icon is removed from the menu bar.

--- a/App/SwipeIntercept.swift
+++ b/App/SwipeIntercept.swift
@@ -275,12 +275,18 @@ func swipeTapCallback(proxy: CGEventTapProxy, type: CGEventType,
 /// it — measured on macOS 26, natural scrolling OFF: a left-to-right swipe
 /// reports progress +0.045 and must move right, same rule as ON.
 ///
+/// The user's "Invert swipe direction" preference is applied last, on top of
+/// the resolved system convention (`gSwipeDirectionInverted`).
+///
 /// - Parameter sign: A non-zero swipe progress or X velocity sample.
 /// - Returns: `true` when the swipe targets the next space to the right.
 private func isRightSwipe(_ sign: Double) -> Bool {
-    if requiresEventAugmentation() { return sign < 0 }
-    if kSwipeDirectionReversed     { return sign > 0 }
-    return sign < 0
+    let isRight: Bool
+    if requiresEventAugmentation()  { isRight = sign < 0 }
+    else if kSwipeDirectionReversed { isRight = sign > 0 }
+    else                            { isRight = sign < 0 }
+
+    return gSwipeDirectionInverted ? !isRight : isRight
 }
 
 /// Fires the instant switch replacing an intercepted swipe, mirroring the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,15 @@ both modes and any correction on top of it double-flips the result. Measured on 
 move right — the same rule as ON. A direction complaint is far more likely to be the
 synthetic-echo bug below than a scrolling-preference bug.
 
+**"Invert swipe direction"** (`gSwipeDirectionInverted`, off by default) flips the
+result of `isRightSwipe` *after* the release table above has been applied — a user
+preference for people who want the opposite of the system behavior, and an escape
+hatch if a future macOS flips the sign again before Space Rabbit is updated. It is
+deliberately Feature 3-only: the keyboard and auto-follow paths derive their direction
+from a target space, not from a gesture sign, so there is nothing to invert there. Do
+**not** reach for it when diagnosing a direction bug — a wrong default direction is a
+bug in the table above (or the synthetic-echo bug below), not a missing preference.
+
 **Synthetic-event marker (`kSyntheticGestureMarker`)** — Space Rabbit's own synthetic
 gestures post into the same session tap and would loop right back into this tap.
 Every posting path in `SpaceSwitching.swift` calls `markSyntheticGesture(_:)` on each
@@ -287,6 +296,7 @@ All runtime state is module-level globals (not a singleton class). This is inten
 | `gInstantSwitchEnabled` | `Bool` | Feature 1 toggle |
 | `gAutoFollowEnabled` | `Bool` | Feature 2 toggle |
 | `gTrackpadSwipeEnabled` | `Bool` | Feature 3 toggle (default **false** — opt-in) |
+| `gSwipeDirectionInverted` | `Bool` | Reverses the direction of an intercepted swipe (Feature 3 only, default **false**) |
 | `gSwipeTracking` / `gSwipeFired` | `Bool` | Per-gesture state of the swipe intercept (reset via `resetSwipeIntercept()`) |
 | `gSwitchSpeed` | `Double` | Transition speed slider tick (0.0–1.0 in 0.25 steps; 0.0 = native macOS animation, 1.0 = instant) |
 | `gLastSpaceSwitchTime` | `Date` | For auto-follow suppression (initialized to `.distantPast`). Stamped by Features 1/3 and by non-auto-follow space changes |
@@ -300,7 +310,7 @@ All runtime state is module-level globals (not a singleton class). This is inten
 
 ### UserDefaults keys (`Defaults` enum)
 
-`spacerabbit.enabled`, `spacerabbit.instantSwitch`, `spacerabbit.autoFollow`, `spacerabbit.threeFingerSwipe` (the "Instant Trackpad Swipe" toggle — legacy spelling kept deliberately, see `Defaults.trackpadSwipe`), `spacerabbit.switchSpeed`, `spacerabbit.switchCount`, `spacerabbit.showMenuBarIcon`,
+`spacerabbit.enabled`, `spacerabbit.instantSwitch`, `spacerabbit.autoFollow`, `spacerabbit.threeFingerSwipe` (the "Instant Trackpad Swipe" toggle — legacy spelling kept deliberately, see `Defaults.trackpadSwipe`), `spacerabbit.invertSwipeDirection`, `spacerabbit.switchSpeed`, `spacerabbit.switchCount`, `spacerabbit.showMenuBarIcon`,
 `spacerabbit.lastUpdateCheck`, `spacerabbit.pendingUpdateVersion`,
 `spacerabbit.pendingUpdateURL` (the last three belong to the update throttle — see
 "Update flow"; none has a `g` global, they are read and written where they are used).
@@ -447,9 +457,11 @@ SettingsWindowController (singleton, NSWindowDelegate)
        ├─ AutoStartPaneController — Launch warning banner (orange, hidden when OK)
        │    + Launch at Login (SMAppService)
        ├─ FeaturesPaneController — two groups: Instant switch + Auto-follow +
-       │    Instant trackpad swipe toggles, then Transition speed slider on its
-       │    own (5 ticks, snapping: Normal = native macOS animation / Fast /
-       │    Faster / Fastest / right end cap = "Instant", the default)
+       │    Instant trackpad swipe + Invert swipe direction toggles (the last
+       │    dimmed while trackpad swipe is off — it has no effect then), then
+       │    Transition speed slider on its own (5 ticks, snapping: Normal =
+       │    native macOS animation / Fast / Faster / Fastest / right end cap =
+       │    "Instant", the default)
        ├─ AdvancedPaneController — Instant Dock hide (writes com.apple.dock
        │    autohide-time-modifier, killall Dock) + Show menu bar icon toggle
        │    (statusItem.isVisible; when hidden, relaunching the app reopens


### PR DESCRIPTION
Closes #25.

Swipe goes in the direction when the feature is activated. Adds an option to invert the direction