### PR TITLE
fix: preserve synthetic marker after macOS 27 event rebuild

### DIFF
--- a/App/SpaceSwitching.swift
+++ b/App/SpaceSwitching.swift
@@ -815,13 +815,13 @@ private func postAugmentedSwitchGesture(isRight: Bool, velocity: Double) -> Bool
                                                      velocity: magnitude)
         else { return false }
 
-        // Mark before augmenting: augmentDockSwipeEvent flattens and rebuilds
-        // the event, so the stamp has to be part of what gets flattened.
-        markSyntheticGesture(dockEvent)
-
         guard let augmented    = augmentDockSwipeEvent(dockEvent),
               let gestureEvent = CGEvent(source: nil)
         else { return false }
+
+        // CGEventCreateFromData does not preserve eventSourceUserData, so
+        // stamp the rebuilt event before posting it through the swipe tap.
+        markSyntheticGesture(augmented)
 
         // The companion gesture envelope needs no augmentation
         gestureEvent.setIntegerValueField(kCGSEventTypeField, value: kCGSEventGesture)


### PR DESCRIPTION
## Problem

When Instant Trackpad Swipe was enabled on macOS 27, Space Rabbit could intercept its own synthetic DockSwipe events. Both Ctrl+Arrow switching and trackpad switching then failed.

## Cause

The macOS 27 path rebuilds events with `CGEventCreateFromData`. That rebuild strips `eventSourceUserData`, so the synthetic-event marker applied before rebuilding was lost.

## Fix

Apply the synthetic marker to the rebuilt event before posting it. The companion gesture envelope is still marked as before.

## Verification

- Built with `make app` on macOS 27.0 build 26A5388g.
- Confirmed direct augmented DockSwipe posting works on that build.
- Confirmed Ctrl+Left/Ctrl+Right and trackpad swipes work with both features enabled after this change.