### PR TITLE
feat: configurable shortcut to cycle through spaces

### DIFF
--- a/App/EventTap.swift
+++ b/App/EventTap.swift
@@ -3,7 +3,9 @@
  *
  * Installs a CGEvent tap at the session level to intercept keyDown
  * events that match the user's "Move left/right a space" or
- * "Switch to Desktop N" shortcuts.
+ * "Switch to Desktop N" shortcuts. It also observes keyUp,
+ * flagsChanged, and systemDefined events so the configurable cycle
+ * shortcut can safely support both ordinary chords and bare Fn.
  *
  * When the shortcut is detected:
  *   1. The original key event is swallowed (returns nil to the tap)
@@ -26,6 +28,46 @@ private let kRelevantModifiers: CGEventFlags = [
     .maskControl, .maskCommand, .maskAlternate, .maskShift
 ]
 
+/// CoreGraphics omits a named case for AppKit's `systemDefined` event type
+/// (`NX_SYSDEFINED`), used by media keys and other hardware controls.
+let kSystemDefinedEventType = CGEventType(rawValue: 14)!
+
+/// Tracks a possible bare-Fn press until release. The switch happens on
+/// release so Fn can still be used as a modifier without cycling spaces.
+private var gFnPressState: BareFnPressState = .idle
+
+/// Key-down swallowed for an ordinary configured cycle shortcut. Its key-up
+/// is swallowed too so the frontmost app never receives an orphan release.
+private var gCycleShortcutActiveKeycode: Int64?
+
+// MARK: - Configurable Space Cycling
+
+/// Clears the in-progress bare-Fn candidate.
+private func resetFnPressTracking() {
+    gFnPressState.reset()
+}
+
+/// Clears all state associated with an in-progress cycle shortcut.
+private func resetCycleShortcutTracking() {
+    resetFnPressTracking()
+    gCycleShortcutActiveKeycode = nil
+}
+
+/// Moves to the next space on the display under the cursor, wrapping from
+/// the last space back to the first.
+private func cycleToNextSpace() {
+    guard !CGEventSource.buttonState(.combinedSessionState, button: .left) else { return }
+
+    let (spaceIDs, currentIdx) = getSpaceList()
+    guard currentIdx >= 0, spaceIDs.count > 1 else { return }
+
+    let targetIdx = (currentIdx + 1) % spaceIDs.count
+    if case .switched = switchToSpace(spaceIDs[targetIdx]) {
+        gLastSpaceSwitchTime = Date()
+        gMenu?.recordSwitch()
+    }
+}
+
 // MARK: - Event Tap Callback
 //
 // This is a C-compatible global function used as the CGEvent tap callback.
@@ -34,7 +76,8 @@ private let kRelevantModifiers: CGEventFlags = [
 
 /// CGEvent tap callback that intercepts space-switch keyboard shortcuts.
 ///
-/// Called for every `keyDown` event system-wide (requires Accessibility permission).
+/// Called for the keyboard event types in the event tap's mask system-wide
+/// (requires Accessibility permission).
 /// Returns `nil` to swallow the event (preventing the default animated switch),
 /// or `Unmanaged.passUnretained(event)` to let it through unchanged.
 ///
@@ -51,13 +94,23 @@ func eventTapCallback(proxy: CGEventTapProxy, type: CGEventType,
     // macOS may disable our tap if it takes too long to process an event
     // or if it suspects misbehavior. Re-enable it immediately to stay alive.
     if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+        resetCycleShortcutTracking()
         if let tap = gTap { CGEvent.tapEnable(tap: tap, enable: true) }
         return passthrough
     }
 
-    // Only process keyDown events when both the master switch and
-    // the instant-switch feature are enabled
-    guard type == .keyDown, gEnabled, gInstantSwitchEnabled else {
+    // While Preferences records a replacement shortcut, let AppKit receive
+    // every candidate event without the existing global binding firing.
+    if gIsRecordingCycleShortcut {
+        resetCycleShortcutTracking()
+        return passthrough
+    }
+
+    // Only process keyboard events while the master switch is enabled.
+    guard type == .keyDown || type == .keyUp || type == .flagsChanged
+            || type == kSystemDefinedEventType,
+          gEnabled else {
+        resetCycleShortcutTracking()
         return passthrough
     }
 
@@ -65,8 +118,81 @@ func eventTapCallback(proxy: CGEventTapProxy, type: CGEventType,
     // animated switch — let every shortcut through untouched so the OS
     // handles it exactly as if Space Rabbit weren't running.
     guard !isNativeSwitchSpeed() else {
+        resetCycleShortcutTracking()
         return passthrough
     }
+
+    let flags   = event.flags
+    let keycode = event.getIntegerValueField(.keyboardEventKeycode)
+
+    // Track physical Fn transitions for every configured cycle shortcut. That
+    // lets ordinary navigation-key bindings distinguish their implicit
+    // function flag from an actual extra Fn modifier. A configured bare Fn is
+    // deferred until release and cancelled if another key or modifier is used.
+    if type == .flagsChanged {
+        guard gCycleShortcutEnabled, let cycleShortcut = gCycleShortcut else {
+            resetFnPressTracking()
+            return passthrough
+        }
+
+        guard keycode == kFnKeycode else {
+            gFnPressState.markChorded()
+            return passthrough
+        }
+
+        if flags.contains(.maskSecondaryFn) {
+            // Only a new up -> down transition starts a bare-Fn candidate.
+            // Repeated down events must not erase evidence that Fn was used
+            // with another key.
+            // A modifier may already be held before Fn goes down, so its
+            // flagsChanged event occurred before this candidate existed.
+            gFnPressState.begin(
+                usedAsModifier: !flags.intersection(kRelevantModifiers).isEmpty
+            )
+        } else {
+            let wasBarePress = gFnPressState.finish()
+            if cycleShortcut.isBareFn, wasBarePress { cycleToNextSpace() }
+        }
+        return cycleShortcut.isBareFn ? nil : passthrough
+    }
+
+    // Any ordinary or system-defined keyboard event between Fn down and up
+    // makes this a chord, not a bare-Fn tap. keyUp is included as a safety
+    // net for hardware whose modified key does not expose a matching keyDown.
+    gFnPressState.markChorded()
+
+    // Swallow the release paired with an ordinary configured shortcut.
+    if type == .keyUp {
+        guard gCycleShortcutActiveKeycode == keycode else { return passthrough }
+        gCycleShortcutActiveKeycode = nil
+        return nil
+    }
+
+    // systemDefined is observed only for bare-Fn chord detection. Shortcut
+    // matching itself applies to ordinary keyDown events.
+    guard type == .keyDown else { return passthrough }
+
+    // Match the user-recorded cycle shortcut before the macOS Space bindings.
+    // This feature is independent of the Instant Space switch toggle.
+    if gCycleShortcutEnabled,
+       let shortcut = gCycleShortcut,
+       !shortcut.isBareFn,
+       keycode == shortcut.keycode,
+       (!gFnPressState.isDown || shortcut.isFunctionKey),
+       flags.intersection(shortcut.matchingModifierMask) == shortcut.modifiers {
+        // Preserve native window-manager behavior while a window is dragged.
+        guard !CGEventSource.buttonState(.combinedSessionState, button: .left)
+        else { return passthrough }
+
+        gCycleShortcutActiveKeycode = keycode
+        if event.getIntegerValueField(.keyboardEventAutorepeat) == 0 {
+            cycleToNextSpace()
+        }
+        return nil
+    }
+
+    // The system Space shortcuts still follow the Instant Space switch toggle.
+    guard gInstantSwitchEnabled else { return passthrough }
 
     // Window managers such as Rectangle Pro and Raycast move a window to an
     // adjacent Space by holding its title bar while invoking the system Space
@@ -76,9 +202,6 @@ func eventTapCallback(proxy: CGEventTapProxy, type: CGEventType,
     if CGEventSource.buttonState(.combinedSessionState, button: .left) {
         return passthrough
     }
-
-    let flags   = event.flags
-    let keycode = event.getIntegerValueField(.keyboardEventKeycode)
 
     // Check that exactly the required modifiers are held (no extras).
     // This prevents false positives when e.g. Cmd+Control+Arrow is pressed

--- a/App/MenuBar.swift
+++ b/App/MenuBar.swift
@@ -98,6 +98,10 @@ final class SwoopMenu: NSObject {
             Defaults.enabled:         true,
             Defaults.instantSwitch:   true,
             Defaults.autoFollow:      true,
+            Defaults.cycleShortcutEnabled:   false,
+            Defaults.cycleShortcutKeycode:   kFnKeycode,
+            Defaults.cycleShortcutModifiers: UInt64(0),
+            Defaults.cycleShortcutLabel:     "fn",
             Defaults.switchSpeed:     1.0,
             Defaults.switchCount:     0,
             Defaults.showMenuBarIcon: true,
@@ -108,6 +112,25 @@ final class SwoopMenu: NSObject {
         gEnabled              = defaults.bool(forKey: Defaults.enabled)
         gInstantSwitchEnabled = defaults.bool(forKey: Defaults.instantSwitch)
         gAutoFollowEnabled    = defaults.bool(forKey: Defaults.autoFollow)
+        gCycleShortcutEnabled = defaults.bool(forKey: Defaults.cycleShortcutEnabled)
+
+        let cycleKeycode = (defaults.object(forKey: Defaults.cycleShortcutKeycode) as? NSNumber)?
+            .int64Value ?? kFnKeycode
+        if cycleKeycode >= 0 {
+            let rawModifiers = (defaults.object(
+                forKey: Defaults.cycleShortcutModifiers
+            ) as? NSNumber)?.uint64Value ?? 0
+            let keyLabel = defaults.string(forKey: Defaults.cycleShortcutLabel) ?? "fn"
+            gCycleShortcut = CycleShortcut(
+                keycode: cycleKeycode,
+                modifiers: CGEventFlags(rawValue: rawModifiers),
+                keyLabel: keyLabel
+            )
+        } else {
+            gCycleShortcut = nil
+            gCycleShortcutEnabled = false
+        }
+
         gSwitchSpeed          = defaults.double(forKey: Defaults.switchSpeed)
         gSwitchCount          = defaults.integer(forKey: Defaults.switchCount)
         gSwitchCountSaved     = gSwitchCount

--- a/App/MenuBar.swift
+++ b/App/MenuBar.swift
@@ -72,6 +72,7 @@ final class SwoopMenu: NSObject {
     private let instantSwitchItem:     NSMenuItem
     private let autoFollowItem:        NSMenuItem
     private let trackpadSwipeItem:     NSMenuItem
+    private let cycleSpacesItem:       NSMenuItem
     private let statsItem:             NSMenuItem
 
     /// Header row at the top of the menu: app name + master enable switch.
@@ -152,6 +153,9 @@ final class SwoopMenu: NSObject {
         trackpadSwipeItem = NSMenuItem(title: L("menu.instantTrackpadSwipe"),
                                        action: #selector(toggleTrackpadSwipe(_:)),
                                        keyEquivalent: "t")
+        cycleSpacesItem   = NSMenuItem(title: L("settings.features.cycleSpaces"),
+                                       action: #selector(toggleCycleSpaces(_:)),
+                                       keyEquivalent: "c")
         statsItem         = NSMenuItem(title: "", action: nil, keyEquivalent: "")
 
         super.init()
@@ -232,8 +236,11 @@ final class SwoopMenu: NSObject {
         instantSwitchItem.state     = gInstantSwitchEnabled    ? .on : .off
         autoFollowItem.target       = self
         autoFollowItem.state        = gAutoFollowEnabled       ? .on : .off
-        trackpadSwipeItem.target = self
-        trackpadSwipeItem.state  = gTrackpadSwipeEnabled ? .on : .off
+        trackpadSwipeItem.target   = self
+        trackpadSwipeItem.state    = gTrackpadSwipeEnabled ? .on : .off
+        cycleSpacesItem.target     = self
+        cycleSpacesItem.state      = gCycleShortcutEnabled ? .on : .off
+        cycleSpacesItem.isEnabled  = !isNativeSwitchSpeed()
         statsItem.isEnabled         = false  // Non-interactive display item
     }
 
@@ -253,6 +260,11 @@ final class SwoopMenu: NSObject {
                              accessibilityDescription: nil) {
             img.isTemplate = true
             trackpadSwipeItem.image = img
+        }
+        if let img = NSImage(systemSymbolName: "arrow.triangle.2.circlepath",
+                             accessibilityDescription: nil) {
+            img.isTemplate = true
+            cycleSpacesItem.image = img
         }
         if let img = NSImage(systemSymbolName: "timer",
                              accessibilityDescription: nil) {
@@ -282,6 +294,7 @@ final class SwoopMenu: NSObject {
         statusMenu.addItem(instantSwitchItem)
         statusMenu.addItem(autoFollowItem)
         statusMenu.addItem(trackpadSwipeItem)
+        statusMenu.addItem(cycleSpacesItem)
         statusMenu.addItem(.separator())
 
         // Statistics section
@@ -340,6 +353,7 @@ final class SwoopMenu: NSObject {
             // it so right-click continues to work (NSStatusItem only supports
             // either a menu OR an action, not both simultaneously).
             updateLaunchWarning()
+            syncMenuItems()
             statusItem.menu = statusMenu
             sender.performClick(nil)
             statusItem.menu = nil
@@ -557,7 +571,12 @@ final class SwoopMenu: NSObject {
     func syncMenuItems() {
         instantSwitchItem.state    = gInstantSwitchEnabled    ? .on : .off
         autoFollowItem.state       = gAutoFollowEnabled       ? .on : .off
-        trackpadSwipeItem.state = gTrackpadSwipeEnabled ? .on : .off
+        trackpadSwipeItem.state    = gTrackpadSwipeEnabled    ? .on : .off
+        cycleSpacesItem.state      = gCycleShortcutEnabled    ? .on : .off
+        cycleSpacesItem.isEnabled  = !isNativeSwitchSpeed()
+        cycleSpacesItem.toolTip    = isNativeSwitchSpeed()
+            ? L("settings.features.cycleSpaces.normalWarning")
+            : nil
     }
 
     @objc private func toggleInstantSwitch(_ sender: NSMenuItem) {
@@ -579,6 +598,16 @@ final class SwoopMenu: NSObject {
         sender.state = gTrackpadSwipeEnabled ? .on : .off
         UserDefaults.standard.set(gTrackpadSwipeEnabled, forKey: Defaults.trackpadSwipe)
         updateSwipeTap()
+        SettingsWindowController.shared.syncPanes()
+    }
+
+    @objc private func toggleCycleSpaces(_ sender: NSMenuItem) {
+        gCycleShortcutEnabled.toggle()
+        if gCycleShortcutEnabled, gCycleShortcut == nil {
+            gCycleShortcut = .fn
+        }
+        sender.state = gCycleShortcutEnabled ? .on : .off
+        persistCycleShortcut()
         SettingsWindowController.shared.syncPanes()
     }
 

--- a/App/Resources/de.lproj/Localizable.strings
+++ b/App/Resources/de.lproj/Localizable.strings
@@ -81,6 +81,10 @@
 
 "settings.features.instantSpaceSwitch" = "Sofortiger Space-Wechsel";
 "settings.features.instantAppSwitch" = "Sofortiger App-Wechsel";
+"settings.features.cycleSpaces" = "Spaces durchlaufen";
+"settings.features.cycleSpaces.normalWarning" = "„Spaces durchlaufen“ ist nicht verfügbar, wenn die Übergangsgeschwindigkeit auf „Normal“ eingestellt ist.";
+"settings.features.shortcut.recording" = "Kurzbefehl drücken…";
+"settings.features.shortcut.none" = "Keiner";
 "settings.features.transitionSpeed" = "Übergangsgeschwindigkeit";
 
 /* Transition-speed slider ticks, slowest to fastest. "Normal" is macOS's own

--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 "settings.features.instantSpaceSwitch" = "Instant Space switch";
 "settings.features.instantAppSwitch" = "Instant App switch";
 "settings.features.cycleSpaces" = "Cycle Spaces";
-"settings.features.cycleSpaces.normalWarning" = "Cycle Spaces is unavailable when the transition speed is set to Normal.";
+"settings.features.cycleSpaces.normalWarning" = "Unavailable when the transition speed is set to Normal";
 "settings.features.shortcut.recording" = "Press shortcut…";
 "settings.features.shortcut.none" = "None";
 "settings.features.transitionSpeed" = "Transition speed";

--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -83,6 +83,10 @@
 
 "settings.features.instantSpaceSwitch" = "Instant Space switch";
 "settings.features.instantAppSwitch" = "Instant App switch";
+"settings.features.cycleSpaces" = "Cycle Spaces";
+"settings.features.cycleSpaces.normalWarning" = "Cycle Spaces is unavailable when the transition speed is set to Normal.";
+"settings.features.shortcut.recording" = "Press shortcut…";
+"settings.features.shortcut.none" = "None";
 "settings.features.transitionSpeed" = "Transition speed";
 
 /* Transition-speed slider ticks, slowest to fastest. "Normal" is macOS's own

--- a/App/Resources/es.lproj/Localizable.strings
+++ b/App/Resources/es.lproj/Localizable.strings
@@ -83,6 +83,10 @@
 
 "settings.features.instantSpaceSwitch" = "Cambio de espacio instantáneo";
 "settings.features.instantAppSwitch" = "Cambio de app instantáneo";
+"settings.features.cycleSpaces" = "Recorrer espacios";
+"settings.features.cycleSpaces.normalWarning" = "Recorrer espacios no está disponible cuando la velocidad de transición está configurada como «Normal».";
+"settings.features.shortcut.recording" = "Pulsa una función rápida…";
+"settings.features.shortcut.none" = "Ninguna";
 "settings.features.transitionSpeed" = "Velocidad de transición";
 
 /* Transition-speed slider ticks, slowest to fastest. "Normal" is macOS's own

--- a/App/Resources/fr.lproj/Localizable.strings
+++ b/App/Resources/fr.lproj/Localizable.strings
@@ -85,6 +85,10 @@
 
 "settings.features.instantSpaceSwitch" = "Changement d’Espace instantané";
 "settings.features.instantAppSwitch" = "Changement d’app instantané";
+"settings.features.cycleSpaces" = "Parcourir les Espaces";
+"settings.features.cycleSpaces.normalWarning" = "« Parcourir les Espaces » n’est pas disponible lorsque la vitesse de transition est réglée sur « Normale ».";
+"settings.features.shortcut.recording" = "Appuyez sur un raccourci…";
+"settings.features.shortcut.none" = "Aucun";
 "settings.features.transitionSpeed" = "Vitesse de transition";
 
 /* Transition-speed slider ticks, slowest to fastest. "Normal" is macOS's own

--- a/App/Resources/pt.lproj/Localizable.strings
+++ b/App/Resources/pt.lproj/Localizable.strings
@@ -84,6 +84,10 @@
 
 "settings.features.instantSpaceSwitch" = "Mudança de espaço instantânea";
 "settings.features.instantAppSwitch" = "Mudança de app instantânea";
+"settings.features.cycleSpaces" = "Alternar espaços";
+"settings.features.cycleSpaces.normalWarning" = "Alternar espaços não está disponível quando a velocidade da transição está definida como “Normal”.";
+"settings.features.shortcut.recording" = "Pressione um atalho…";
+"settings.features.shortcut.none" = "Nenhum";
 "settings.features.transitionSpeed" = "Velocidade da transição";
 
 /* Transition-speed slider ticks, slowest to fastest. "Normal" is macOS's own

--- a/App/Resources/ru.lproj/Localizable.strings
+++ b/App/Resources/ru.lproj/Localizable.strings
@@ -86,6 +86,10 @@
 
 "settings.features.instantSpaceSwitch" = "Мгновенное переключение столов";
 "settings.features.instantAppSwitch" = "Мгновенное переключение приложений";
+"settings.features.cycleSpaces" = "Переключать столы";
+"settings.features.cycleSpaces.normalWarning" = "Функция «Переключать столы» недоступна, когда скорость перехода установлена на «Обычная».";
+"settings.features.shortcut.recording" = "Нажмите сочетание…";
+"settings.features.shortcut.none" = "Нет";
 "settings.features.transitionSpeed" = "Скорость перехода";
 
 /* Transition-speed slider ticks, slowest to fastest. "Normal" is macOS's own

--- a/App/Resources/zh-Hans.lproj/Localizable.strings
+++ b/App/Resources/zh-Hans.lproj/Localizable.strings
@@ -86,6 +86,10 @@
 
 "settings.features.instantSpaceSwitch" = "即时切换空间";
 "settings.features.instantAppSwitch" = "即时切换应用";
+"settings.features.cycleSpaces" = "循环切换空间";
+"settings.features.cycleSpaces.normalWarning" = "当过渡速度设为“正常”时，循环切换空间不可用。";
+"settings.features.shortcut.recording" = "按下快捷键…";
+"settings.features.shortcut.none" = "无";
 "settings.features.transitionSpeed" = "过渡速度";
 
 /* Transition-speed slider ticks, slowest to fastest. "Normal" is macOS's own

--- a/App/Settings.swift
+++ b/App/Settings.swift
@@ -1033,12 +1033,12 @@ final class FeaturesPaneController: SettingsPaneViewController {
             rowDivider(),
             settingsRow(label: L("settings.features.instantTrackpadSwipe"),
                         control: trackpadSwipeControl),
-            rowDivider(),
-            cycleShortcutRow,
         ])
         let speedGroup = groupBox([
             settingsRow(label: L("settings.features.transitionSpeed"),
                         control: makeSpeedControl()),
+            rowDivider(),
+            cycleShortcutRow,
         ])
         updateCycleShortcutAvailability()
         return [togglesGroup, speedGroup]

--- a/App/Settings.swift
+++ b/App/Settings.swift
@@ -46,6 +46,7 @@ private enum Layout {
     static let aboutSpacing:      CGFloat = 20
     static let speedSliderWidth:  CGFloat = 140
     static let speedTailSpacing:  CGFloat = 3
+    static let shortcutMinWidth:  CGFloat = 92
 }
 
 // MARK: - Panes
@@ -480,6 +481,155 @@ extension SettingsSidebarController: NSTableViewDataSource, NSTableViewDelegate 
 
 // MARK: - Pane Base Class
 
+/// A standard settings row with optional secondary content beneath its title.
+///
+/// Conditional subtitles are inserted into and removed from the arranged-view
+/// hierarchy instead of merely hidden. That makes the row's intrinsic height
+/// deterministic across repeated expand/collapse transitions.
+final class SettingsRowView: NSStackView {
+
+    private let textStack = NSStackView()
+    private let subtitleView: NSView?
+    private let subtitleVerticalPadding: CGFloat
+    var onIntrinsicHeightChanged: (() -> Void)?
+
+    var isSubtitleVisible: Bool {
+        guard let subtitleView else { return false }
+        return textStack.arrangedSubviews.contains { $0 === subtitleView }
+    }
+
+    init(label: String, control: NSView, subtitle: NSView?,
+         subtitleVerticalPadding: CGFloat) {
+        subtitleView            = subtitle
+        self.subtitleVerticalPadding = subtitleVerticalPadding
+        super.init(frame: .zero)
+
+        let labelField = NSTextField(labelWithString: label)
+        labelField.font = .systemFont(ofSize: 13)
+
+        textStack.orientation = .vertical
+        textStack.spacing     = 2
+        textStack.alignment   = .leading
+        textStack.addArrangedSubview(labelField)
+        if let subtitle { textStack.addArrangedSubview(subtitle) }
+
+        orientation = .horizontal
+        spacing     = 10
+        alignment   = .centerY
+        updateVerticalInsets(subtitleVisible: subtitle != nil)
+        setContentHuggingPriority(.required, for: .vertical)
+        setContentCompressionResistancePriority(.required, for: .vertical)
+        addArrangedSubview(textStack)
+        addArrangedSubview(NSView())
+        addArrangedSubview(control)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Presents or removes the optional subtitle and reports whether the
+    /// arranged-view hierarchy changed.
+    func setSubtitleVisible(_ visible: Bool) -> Bool {
+        guard let subtitleView, visible != isSubtitleVisible else { return false }
+
+        if visible {
+            textStack.addArrangedSubview(subtitleView)
+        } else {
+            textStack.removeArrangedSubview(subtitleView)
+            subtitleView.removeFromSuperview()
+        }
+        updateVerticalInsets(subtitleVisible: visible)
+
+        textStack.invalidateIntrinsicContentSize()
+        textStack.needsLayout = true
+        invalidateIntrinsicContentSize()
+        needsLayout = true
+        onIntrinsicHeightChanged?()
+        return true
+    }
+
+    private func updateVerticalInsets(subtitleVisible: Bool) {
+        let extra = subtitleVisible ? subtitleVerticalPadding : 0
+        edgeInsets = NSEdgeInsets(top: Layout.rowVerticalPad + extra,
+                                  left: Layout.rowHorizontalPad,
+                                  bottom: Layout.rowVerticalPad + extra,
+                                  right: Layout.rowHorizontalPad)
+    }
+}
+
+/// Rounded settings card whose height follows its rows' intrinsic content.
+/// Rows notify the card when conditional content changes so AppKit does not
+/// retain a previous `.fill` allocation after a subtitle is removed.
+final class SettingsGroupBox: NSBox {
+
+    private let contentStack = NSStackView()
+
+    /// A borderless custom `NSBox` otherwise keeps part of its previous frame
+    /// in its fitting size after arranged content contracts. Size the card
+    /// directly from the rows so repeated subtitle transitions are reversible.
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: NSView.noIntrinsicMetric,
+               height: contentStack.fittingSize.height)
+    }
+
+    init(views: [NSView]) {
+        super.init(frame: .zero)
+
+        contentStack.orientation = .vertical
+        contentStack.spacing     = 0
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+        contentStack.setContentHuggingPriority(.required, for: .vertical)
+        contentStack.setContentCompressionResistancePriority(.required, for: .vertical)
+
+        for subview in views {
+            subview.translatesAutoresizingMaskIntoConstraints = false
+            contentStack.addArrangedSubview(subview)
+            if let row = subview as? SettingsRowView {
+                row.onIntrinsicHeightChanged = { [weak self] in
+                    self?.contentHeightChanged()
+                }
+            }
+        }
+
+        boxType            = .custom
+        titlePosition      = .noTitle
+        cornerRadius       = Layout.groupCornerRadius
+        borderWidth        = 0
+        borderColor        = .clear
+        fillColor          = .quaternarySystemFill
+        contentViewMargins = .zero
+        setContentHuggingPriority(.required, for: .vertical)
+        setContentCompressionResistancePriority(.required, for: .vertical)
+
+        if let content = contentView {
+            content.addSubview(contentStack)
+            NSLayoutConstraint.activate([
+                contentStack.topAnchor.constraint(equalTo: content.topAnchor),
+                contentStack.bottomAnchor.constraint(equalTo: content.bottomAnchor),
+                contentStack.leadingAnchor.constraint(equalTo: content.leadingAnchor),
+                contentStack.trailingAnchor.constraint(equalTo: content.trailingAnchor),
+            ])
+            NSLayoutConstraint.activate(views.map {
+                $0.widthAnchor.constraint(equalTo: contentStack.widthAnchor)
+            })
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func contentHeightChanged() {
+        contentStack.invalidateIntrinsicContentSize()
+        contentStack.needsLayout = true
+        contentView?.invalidateIntrinsicContentSize()
+        contentView?.needsLayout = true
+        invalidateIntrinsicContentSize()
+        needsLayout = true
+    }
+}
+
 /// Base class for settings panes shown to the right of the sidebar.
 ///
 /// Provides the bold pane header, the outer stack assembly, and the shared
@@ -548,36 +698,45 @@ class SettingsPaneViewController: NSViewController {
 
     // MARK: Row Builder Helpers
 
-    /// Creates a standard settings row: label (+ optional subtitle below)
+    /// Creates a standard settings row: label (+ optional subtitle view below)
     /// with the control pushed to the trailing edge via a flexible spacer.
     ///
     /// - Parameters:
     ///   - label: Primary text label for the setting.
     ///   - control: The interactive control (typically an `NSSwitch`).
-    ///   - subtitle: Optional secondary label shown below the primary label.
-    /// - Returns: A configured `NSView` ready to add to a group box.
+    ///   - subtitle: Optional secondary content shown below the primary label.
+    /// - Returns: A configured row ready to add to a group box.
     func settingsRow(label: String, control: NSView,
-                     subtitle: NSTextField? = nil) -> NSView {
-        let labelField = NSTextField(labelWithString: label)
-        labelField.font = .systemFont(ofSize: 13)
+                     subtitle: NSView? = nil,
+                     subtitleVerticalPadding: CGFloat = 0) -> SettingsRowView {
+        SettingsRowView(label: label, control: control, subtitle: subtitle,
+                        subtitleVerticalPadding: subtitleVerticalPadding)
+    }
 
-        let textStack = NSStackView()
-        textStack.orientation = .vertical
-        textStack.spacing     = 2
-        textStack.alignment   = .leading
-        textStack.addArrangedSubview(labelField)
-        if let subtitle = subtitle { textStack.addArrangedSubview(subtitle) }
+    /// Creates the compact warning subtitle used by System Settings-style
+    /// conditional rows: a yellow warning symbol with muted explanatory text.
+    /// Its small vertical inset gives expanded rows a little extra breathing
+    /// room without changing the standard padding of compact rows.
+    func makeWarningSubtitle(_ text: String) -> NSView {
+        let symbolConfig = NSImage.SymbolConfiguration(pointSize: 10, weight: .medium)
+        let icon = NSImageView()
+        icon.image = NSImage(systemSymbolName: "exclamationmark.triangle.fill",
+                             accessibilityDescription: nil)?
+            .withSymbolConfiguration(symbolConfig)
+        icon.contentTintColor = .systemYellow
+        icon.setContentHuggingPriority(.required, for: .horizontal)
 
-        let row = NSStackView()
-        row.orientation = .horizontal
-        row.spacing     = 10
-        row.alignment   = .centerY
-        row.edgeInsets  = NSEdgeInsets(top: Layout.rowVerticalPad, left: Layout.rowHorizontalPad,
-                                       bottom: Layout.rowVerticalPad, right: Layout.rowHorizontalPad)
-        row.addArrangedSubview(textStack)
-        row.addArrangedSubview(NSView())   // Flexible spacer pushes the control to the right
-        row.addArrangedSubview(control)
-        return row
+        let label = NSTextField(wrappingLabelWithString: text)
+        label.font                    = .systemFont(ofSize: 11)
+        label.textColor               = .secondaryLabelColor
+        label.preferredMaxLayoutWidth = 275
+
+        let warning = NSStackView(views: [icon, label])
+        warning.orientation = .horizontal
+        warning.spacing     = 5
+        warning.alignment   = .centerY
+        warning.edgeInsets  = NSEdgeInsets(top: 2, left: 0, bottom: 2, right: 0)
+        return warning
     }
 
     /// Wraps the given views in a rounded, subtly-filled group card
@@ -586,39 +745,8 @@ class SettingsPaneViewController: NSViewController {
     ///
     /// - Parameter views: Rows (and dividers) stacked top to bottom.
     /// - Returns: The group box, ready to return from `buildContent()`.
-    func groupBox(_ views: [NSView]) -> NSView {
-        let stack = NSStackView()
-        stack.orientation = .vertical
-        stack.spacing     = 0
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        for subview in views {
-            subview.translatesAutoresizingMaskIntoConstraints = false
-            stack.addArrangedSubview(subview)
-        }
-
-        let box = NSBox()
-        box.boxType            = .custom
-        box.titlePosition      = .noTitle
-        box.cornerRadius       = Layout.groupCornerRadius
-        box.borderWidth        = 0
-        box.borderColor        = .clear
-        box.fillColor          = .quaternarySystemFill
-        box.contentViewMargins = .zero
-
-        if let content = box.contentView {
-            content.addSubview(stack)
-            NSLayoutConstraint.activate([
-                stack.topAnchor.constraint(equalTo: content.topAnchor),
-                stack.bottomAnchor.constraint(equalTo: content.bottomAnchor),
-                stack.leadingAnchor.constraint(equalTo: content.leadingAnchor),
-                stack.trailingAnchor.constraint(equalTo: content.trailingAnchor),
-            ])
-            // Stretch every row to the group's full width
-            NSLayoutConstraint.activate(views.map {
-                $0.widthAnchor.constraint(equalTo: stack.widthAnchor)
-            })
-        }
-        return box
+    func groupBox(_ views: [NSView]) -> SettingsGroupBox {
+        SettingsGroupBox(views: views)
     }
 
     /// Creates a horizontal separator line between settings rows,
@@ -811,13 +939,17 @@ final class AutoStartPaneController: SettingsPaneViewController {
 
 // MARK: - Features Pane
 
-/// The "Features" pane: instant space switch, auto-follow, transition speed.
+/// The "Features" pane: instant space switch, auto-follow, configurable
+/// cycle shortcut, and transition speed.
 final class FeaturesPaneController: SettingsPaneViewController {
 
     override var paneTitle: String { SettingsPane.features.title }
 
     private var instantSwitchControl: NSSwitch!
     private var autoFollowControl:    NSSwitch!
+    private var cycleShortcutControl: NSSwitch!
+    private var shortcutRecorder:     ShortcutRecorderButton!
+    private var cycleShortcutRow:     SettingsRowView!
     private var speedSlider:          NSSlider!
     private var speedValueLabel:      NSTextField!
     private var speedBoltIcon:        NSImageView!
@@ -825,6 +957,37 @@ final class FeaturesPaneController: SettingsPaneViewController {
     override func buildContent() -> [NSView] {
         instantSwitchControl = makeSwitch(gInstantSwitchEnabled, #selector(toggleInstantSwitch))
         autoFollowControl    = makeSwitch(gAutoFollowEnabled,    #selector(toggleAutoFollow))
+        cycleShortcutControl = makeSwitch(
+            gCycleShortcutEnabled,
+            #selector(toggleCycleShortcut)
+        )
+
+        shortcutRecorder = ShortcutRecorderButton(
+            shortcut: gCycleShortcut,
+            recordingTitle: L("settings.features.shortcut.recording"),
+            emptyTitle: L("settings.features.shortcut.none")
+        )
+        shortcutRecorder.onChange = { [weak self] shortcut in
+            self?.cycleShortcutChanged(shortcut)
+        }
+        shortcutRecorder.widthAnchor.constraint(
+            greaterThanOrEqualToConstant: Layout.shortcutMinWidth
+        ).isActive = true
+        let cycleShortcutWarning = makeWarningSubtitle(
+            L("settings.features.cycleSpaces.normalWarning")
+        )
+
+        let cycleControls = NSStackView(views: [shortcutRecorder, cycleShortcutControl])
+        cycleControls.orientation = .horizontal
+        cycleControls.spacing     = 10
+        cycleControls.alignment   = .centerY
+
+        cycleShortcutRow = settingsRow(
+            label: L("settings.features.cycleSpaces"),
+            control: cycleControls,
+            subtitle: cycleShortcutWarning,
+            subtitleVerticalPadding: 1
+        )
 
         let togglesGroup = groupBox([
             settingsRow(label: L("settings.features.instantSpaceSwitch"),
@@ -832,11 +995,14 @@ final class FeaturesPaneController: SettingsPaneViewController {
             rowDivider(),
             settingsRow(label: L("settings.features.instantAppSwitch"),
                         control: autoFollowControl),
+            rowDivider(),
+            cycleShortcutRow,
         ])
         let speedGroup = groupBox([
             settingsRow(label: L("settings.features.transitionSpeed"),
                         control: makeSpeedControl()),
         ])
+        updateCycleShortcutAvailability()
         return [togglesGroup, speedGroup]
     }
 
@@ -847,8 +1013,11 @@ final class FeaturesPaneController: SettingsPaneViewController {
         // menu bar while this pane was not visible
         instantSwitchControl.state = gInstantSwitchEnabled ? .on : .off
         autoFollowControl.state    = gAutoFollowEnabled    ? .on : .off
+        cycleShortcutControl.state = gCycleShortcutEnabled ? .on : .off
+        shortcutRecorder.setShortcut(gCycleShortcut)
         speedSlider.doubleValue    = gSwitchSpeed
         updateSpeedDisplay()
+        updateCycleShortcutAvailability()
     }
 
     /// Builds the transition-speed control: a 5-tick slider with a trailing
@@ -912,6 +1081,31 @@ final class FeaturesPaneController: SettingsPaneViewController {
         speedValueLabel.textColor   = isInstant ? .labelColor : .secondaryLabelColor
         speedBoltIcon.contentTintColor = .labelColor
         speedBoltIcon.isHidden         = !isInstant
+    }
+
+    /// Makes Cycle Spaces temporarily unavailable at the Normal speed without
+    /// altering its saved toggle or shortcut. Moving the slider away from
+    /// Normal restores the controls and the user's prior configuration.
+    private func updateCycleShortcutAvailability(resize: Bool = false) {
+        let unavailable = isNativeSwitchSpeed()
+        let visibilityChanged = cycleShortcutRow.setSubtitleVisible(unavailable)
+        cycleShortcutControl.isEnabled = !unavailable
+        shortcutRecorder.isEnabled     = !unavailable
+
+        let explanation = unavailable
+            ? L("settings.features.cycleSpaces.normalWarning")
+            : nil
+        cycleShortcutControl.toolTip = explanation
+        shortcutRecorder.toolTip     = explanation
+
+        if visibilityChanged {
+            // Resolve the stack's new intrinsic height before the root
+            // controller asks for the pane's fitting size. This keeps slider
+            // tracking from leaving behind the expanded row height.
+            view.needsLayout = true
+            view.layoutSubtreeIfNeeded()
+            if resize { resizePaneToFit() }
+        }
     }
 
     /// Localized names of the five slider ticks, slowest first — "Normal" being
@@ -986,10 +1180,29 @@ final class FeaturesPaneController: SettingsPaneViewController {
         gMenu?.syncMenuItems()
     }
 
+    @objc private func toggleCycleShortcut() {
+        gCycleShortcutEnabled = cycleShortcutControl.state == .on
+        if gCycleShortcutEnabled, gCycleShortcut == nil {
+            gCycleShortcut = .fn
+            shortcutRecorder.setShortcut(gCycleShortcut)
+        }
+        persistCycleShortcut()
+    }
+
+    /// Applies a shortcut recorded (or cleared) by the recorder field.
+    /// Recording enables the feature; clearing it turns the feature off.
+    private func cycleShortcutChanged(_ shortcut: CycleShortcut?) {
+        gCycleShortcut = shortcut
+        gCycleShortcutEnabled = shortcut != nil
+        cycleShortcutControl.state = gCycleShortcutEnabled ? .on : .off
+        persistCycleShortcut()
+    }
+
     @objc private func speedChanged() {
         gSwitchSpeed = speedSlider.doubleValue
         UserDefaults.standard.set(gSwitchSpeed, forKey: Defaults.switchSpeed)
         updateSpeedDisplay()
+        updateCycleShortcutAvailability(resize: true)
     }
 }
 

--- a/App/Settings.swift
+++ b/App/Settings.swift
@@ -1224,6 +1224,7 @@ final class FeaturesPaneController: SettingsPaneViewController {
             shortcutRecorder.setShortcut(gCycleShortcut)
         }
         persistCycleShortcut()
+        gMenu?.syncMenuItems()
     }
 
     /// Applies a shortcut recorded (or cleared) by the recorder field.
@@ -1233,6 +1234,7 @@ final class FeaturesPaneController: SettingsPaneViewController {
         gCycleShortcutEnabled = shortcut != nil
         cycleShortcutControl.state = gCycleShortcutEnabled ? .on : .off
         persistCycleShortcut()
+        gMenu?.syncMenuItems()
     }
 
     @objc private func toggleTrackpadSwipe() {
@@ -1247,6 +1249,7 @@ final class FeaturesPaneController: SettingsPaneViewController {
         UserDefaults.standard.set(gSwitchSpeed, forKey: Defaults.switchSpeed)
         updateSpeedDisplay()
         updateCycleShortcutAvailability(resize: true)
+        gMenu?.syncMenuItems()
     }
 }
 

--- a/App/ShortcutRecorder.swift
+++ b/App/ShortcutRecorder.swift
@@ -1,0 +1,234 @@
+/*
+ * ShortcutRecorder.swift — Native-style global shortcut recording control
+ *
+ * Captures safe keyboard shortcuts for cycling Spaces. Bare Fn/Globe is
+ * recognized on release, while F1 through F20 are recorded by keycode so
+ * they work in either macOS top-row keyboard mode.
+ */
+
+import Cocoa
+import CoreGraphics
+
+/// Native-style field for recording a global keyboard shortcut.
+///
+/// A local event monitor is installed only while recording so shortcuts such
+/// as Command-W reach the field before AppKit treats them as window commands.
+/// The global event tap stands down concurrently via
+/// `gIsRecordingCycleShortcut`.
+final class ShortcutRecorderButton: NSButton {
+
+    /// Called with the new shortcut, or `nil` when the user clears it.
+    var onChange: ((CycleShortcut?) -> Void)?
+
+    private var shortcut: CycleShortcut?
+    private let recordingTitle: String
+    private let emptyTitle: String
+    private var localMonitor: Any?
+    private var recordingObservers: [NSObjectProtocol] = []
+    private var isRecording = false
+    private var recordingFnState: BareFnPressState = .idle
+
+    override var acceptsFirstResponder: Bool { true }
+
+    init(shortcut: CycleShortcut?, recordingTitle: String, emptyTitle: String) {
+        self.shortcut = shortcut
+        self.recordingTitle = recordingTitle
+        self.emptyTitle = emptyTitle
+        super.init(frame: .zero)
+
+        bezelStyle  = .rounded
+        controlSize = .regular
+        font        = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        target      = self
+        action      = #selector(beginRecording)
+        updateTitle()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        stopRecording()
+    }
+
+    /// Refreshes the displayed binding when Preferences reappears.
+    func setShortcut(_ shortcut: CycleShortcut?) {
+        self.shortcut = shortcut
+        if !isRecording { updateTitle() }
+    }
+
+    @objc private func beginRecording() {
+        guard !isRecording else { return }
+
+        isRecording = true
+        recordingFnState.reset()
+        gIsRecordingCycleShortcut = true
+        title = recordingTitle
+        window?.makeFirstResponder(self)
+
+        localMonitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.keyDown, .flagsChanged, .systemDefined]
+        ) { [weak self] event in
+            guard let self, self.isRecording else { return event }
+            self.handleRecordingEvent(event)
+            return nil
+        }
+
+        let center = NotificationCenter.default
+        if let window {
+            recordingObservers.append(center.addObserver(
+                forName: NSWindow.didResignKeyNotification,
+                object: window, queue: .main
+            ) { [weak self] _ in self?.cancelRecording() })
+        }
+        recordingObservers.append(center.addObserver(
+            forName: NSApplication.didResignActiveNotification,
+            object: NSApp, queue: .main
+        ) { [weak self] _ in self?.cancelRecording() })
+    }
+
+    override func resignFirstResponder() -> Bool {
+        let didResign = super.resignFirstResponder()
+        if didResign { stopRecording() }
+        return didResign
+    }
+
+    /// Handles one locally-monitored key event while recording.
+    private func handleRecordingEvent(_ event: NSEvent) {
+        switch event.type {
+        case .flagsChanged:
+            handleModifierChange(event)
+            return
+        case .systemDefined:
+            recordingFnState.markChorded()
+            return
+        case .keyDown:
+            break
+        default:
+            return
+        }
+
+        let fnWasDown = recordingFnState.isDown
+        recordingFnState.markChorded()
+
+        let keycode = Int64(event.keyCode)
+        let modifiers = cycleModifiers(from: event.modifierFlags)
+
+        // Escape cancels without changing the existing shortcut.
+        if keycode == 53 {
+            cancelRecording()
+            return
+        }
+
+        guard let (label, isFunctionKey) = keyLabel(for: event) else {
+            NSSound.beep()
+            return
+        }
+
+        // Physical Fn chords are not recordable, except when Fn is how the
+        // keyboard produces an F-key in the current macOS top-row mode.
+        guard !fnWasDown || isFunctionKey else {
+            NSSound.beep()
+            return
+        }
+
+        // An unmodified Delete or Forward Delete clears the field.
+        if (keycode == 51 || keycode == 117), modifiers.isEmpty {
+            commit(nil)
+            return
+        }
+
+        // Bare typing keys would fire during ordinary text entry. Require
+        // Control, Option, or Command; standalone F-keys remain valid.
+        let safeModifiers: CGEventFlags = [
+            .maskControl, .maskAlternate, .maskCommand
+        ]
+        guard isFunctionKey || !modifiers.intersection(safeModifiers).isEmpty else {
+            NSSound.beep()
+            return
+        }
+
+        commit(CycleShortcut(keycode: keycode, modifiers: modifiers, keyLabel: label))
+    }
+
+    /// Recognizes Fn by itself while leaving other modifier-only presses
+    /// available as part of a later regular-key shortcut.
+    private func handleModifierChange(_ event: NSEvent) {
+        let keycode = Int64(event.keyCode)
+        guard keycode == kFnKeycode else {
+            recordingFnState.markChorded()
+            return
+        }
+
+        if event.modifierFlags.contains(.function) {
+            recordingFnState.begin(
+                usedAsModifier: !cycleModifiers(from: event.modifierFlags).isEmpty
+            )
+        } else {
+            if recordingFnState.finish() { commit(.fn) }
+        }
+    }
+
+    /// Converts AppKit modifier flags to the CoreGraphics representation used
+    /// by the session event tap.
+    private func cycleModifiers(from flags: NSEvent.ModifierFlags) -> CGEventFlags {
+        var result = CGEventFlags()
+        if flags.contains(.control)  { result.insert(.maskControl) }
+        if flags.contains(.option)   { result.insert(.maskAlternate) }
+        if flags.contains(.shift)    { result.insert(.maskShift) }
+        if flags.contains(.command)  { result.insert(.maskCommand) }
+        return result
+    }
+
+    /// Returns a compact key label and whether the key is an F-key (which is
+    /// safe to bind without another modifier).
+    private func keyLabel(for event: NSEvent) -> (label: String, isFunctionKey: Bool)? {
+        let special: [Int64: String] = [
+            36: "↩", 48: "⇥", 49: "␣", 51: "⌫", 53: "⎋", 57: "⇪",
+            63: "fn", 115: "↖", 116: "⇞", 117: "⌦", 119: "↘", 121: "⇟",
+            123: "←", 124: "→", 125: "↓", 126: "↑",
+        ]
+        let keycode = Int64(event.keyCode)
+        if let label = CycleShortcut.functionKeyLabels[keycode] { return (label, true) }
+        if let label = special[keycode]      { return (label, false) }
+
+        guard let characters = event.charactersIgnoringModifiers,
+              !characters.isEmpty else { return nil }
+        return (characters.uppercased(), false)
+    }
+
+    /// Commits a recorded value, updates the field, and leaves recording mode.
+    private func commit(_ shortcut: CycleShortcut?) {
+        self.shortcut = shortcut
+        onChange?(shortcut)
+        stopRecording()
+        window?.makeFirstResponder(nil)
+    }
+
+    private func cancelRecording() {
+        stopRecording()
+        if window?.firstResponder === self {
+            window?.makeFirstResponder(nil)
+        }
+    }
+
+    /// Removes the temporary monitor and restores the field title.
+    private func stopRecording() {
+        if let localMonitor {
+            NSEvent.removeMonitor(localMonitor)
+            self.localMonitor = nil
+        }
+        let center = NotificationCenter.default
+        recordingObservers.forEach(center.removeObserver)
+        recordingObservers.removeAll()
+        isRecording = false
+        recordingFnState.reset()
+        gIsRecordingCycleShortcut = false
+        updateTitle()
+    }
+
+    private func updateTitle() {
+        title = shortcut?.displayString ?? emptyTitle
+    }
+}

--- a/App/State.swift
+++ b/App/State.swift
@@ -34,6 +34,10 @@ var gInstantSwitchEnabled: Bool = true
 /// Only effective when `gEnabled` is also `true`.
 var gAutoFollowEnabled: Bool = true
 
+/// Whether the configurable global cycle shortcut is active.
+/// Only effective when `gEnabled` is true and the transition speed is not Normal.
+var gCycleShortcutEnabled: Bool = false
+
 /// Space-switch transition speed as a slider tick position (0.0–1.0 in
 /// steps of 0.25). 1.0 (the end cap) means instant — no animation at all.
 /// 0.0 ("Normal") means macOS's native animation: Space Rabbit posts no
@@ -74,6 +78,119 @@ var gSwitchCountSaved: Int = 0
 /// A keyboard shortcut: virtual keycode plus its exact modifier set.
 typealias KeyBinding = (keycode: Int64, mods: CGEventFlags)
 
+/// Virtual keycode emitted by the Fn/Globe key on Apple keyboards.
+let kFnKeycode: Int64 = 63
+
+/// Modifiers checked when matching ordinary configurable cycle shortcuts.
+/// Fn is included to reject it as an unrecorded extra modifier. The automatic
+/// function flag on special/F-keys is normalized separately.
+let kCycleShortcutModifiers: CGEventFlags = [
+    .maskControl, .maskCommand, .maskAlternate, .maskShift, .maskSecondaryFn
+]
+
+/// State of a possible bare-Fn press while waiting for its release.
+enum BareFnPressState {
+    case idle
+    case candidate
+    case chorded
+
+    var isDown: Bool {
+        if case .idle = self { return false }
+        return true
+    }
+
+    mutating func begin(usedAsModifier: Bool) {
+        guard case .idle = self else { return }
+        self = usedAsModifier ? .chorded : .candidate
+    }
+
+    mutating func markChorded() {
+        guard isDown else { return }
+        self = .chorded
+    }
+
+    /// Finishes the press and returns whether it remained a bare-Fn tap.
+    mutating func finish() -> Bool {
+        let wasBare: Bool
+        if case .candidate = self { wasBare = true } else { wasBare = false }
+        self = .idle
+        return wasBare
+    }
+
+    mutating func reset() {
+        self = .idle
+    }
+}
+
+/// A persisted global shortcut for cycling to the next Space.
+struct CycleShortcut {
+    /// F-key virtual keycodes and their recorder labels.
+    static let functionKeyLabels: [Int64: String] = [
+        122: "F1", 120: "F2", 99: "F3", 118: "F4", 96: "F5",
+        97: "F6", 98: "F7", 100: "F8", 101: "F9", 109: "F10",
+        103: "F11", 111: "F12", 105: "F13", 107: "F14", 113: "F15",
+        106: "F16", 64: "F17", 79: "F18", 80: "F19", 90: "F20",
+    ]
+
+    /// Non-F keys whose events carry `.maskSecondaryFn` automatically even
+    /// when the physical Fn key is not held. AppKit classifies these as
+    /// function/navigation keys, so that synthesized flag must be ignored
+    /// during modifier matching.
+    private static let implicitFunctionFlagKeycodes: Set<Int64> = [
+        71,                          // Keypad Clear
+        114,                         // Help / Insert
+        115, 116, 117, 119, 121,    // Home, Page Up, Forward Delete, End, Page Down
+        123, 124, 125, 126,         // Arrow keys
+    ]
+
+    let keycode: Int64
+    let modifiers: CGEventFlags
+    let keyLabel: String
+
+    /// Default shortcut used when the feature has not been configured.
+    static let fn = CycleShortcut(keycode: kFnKeycode, modifiers: [], keyLabel: "fn")
+
+    /// Whether this binding represents a tap of Fn/Globe by itself.
+    var isBareFn: Bool { keycode == kFnKeycode && modifiers.isEmpty }
+
+    /// Whether the primary key is F1 through F20.
+    var isFunctionKey: Bool { Self.functionKeyLabels[keycode] != nil }
+
+    /// Whether modifier matching should normalize away the function flag.
+    /// Navigation keys carry it implicitly; F-keys ignore it so both macOS
+    /// top-row modes resolve to the same binding.
+    var normalizesFunctionFlag: Bool {
+        isFunctionKey || Self.implicitFunctionFlagKeycodes.contains(keycode)
+    }
+
+    /// Modifier flags considered when matching this shortcut.
+    var matchingModifierMask: CGEventFlags {
+        normalizesFunctionFlag
+            ? kCycleShortcutModifiers.subtracting(.maskSecondaryFn)
+            : kCycleShortcutModifiers
+    }
+
+    /// Compact macOS-style glyph string shown by the recorder control.
+    var displayString: String {
+        if isBareFn { return keyLabel }
+
+        var result = ""
+        if modifiers.contains(.maskControl)     { result += "⌃" }
+        if modifiers.contains(.maskAlternate)   { result += "⌥" }
+        if modifiers.contains(.maskShift)       { result += "⇧" }
+        if modifiers.contains(.maskCommand)     { result += "⌘" }
+        return result + keyLabel
+    }
+}
+
+/// Configured cycle binding. Defaults to Fn while the feature remains off.
+/// `nil` means the user explicitly cleared the recorder.
+var gCycleShortcut: CycleShortcut? = .fn
+
+/// True while the Preferences shortcut field is recording. The global event
+/// tap passes keyboard events through so the field can receive them locally.
+var gIsRecordingCycleShortcut = false
+
 /// Binding for "move left a space" (default: Control + Left Arrow).
 /// `nil` when the hotkey is disabled in System Settings.
 var gBindingLeft: KeyBinding? = (keycode: 123, mods: .maskControl)
@@ -103,6 +220,10 @@ enum Defaults {
     static let enabled         = "spacerabbit.enabled"
     static let instantSwitch   = "spacerabbit.instantSwitch"
     static let autoFollow      = "spacerabbit.autoFollow"
+    static let cycleShortcutEnabled   = "spacerabbit.cycleShortcut.enabled"
+    static let cycleShortcutKeycode   = "spacerabbit.cycleShortcut.keycode"
+    static let cycleShortcutModifiers = "spacerabbit.cycleShortcut.modifiers"
+    static let cycleShortcutLabel     = "spacerabbit.cycleShortcut.label"
     static let switchSpeed     = "spacerabbit.switchSpeed"
     static let switchCount     = "spacerabbit.switchCount"
     /// When `false`, the rabbit icon is removed from the menu bar.
@@ -111,6 +232,25 @@ enum Defaults {
 }
 
 // MARK: - Persistence
+
+/// Writes the configurable cycle shortcut and its enabled state.
+func persistCycleShortcut() {
+    let defaults = UserDefaults.standard
+    defaults.set(gCycleShortcutEnabled, forKey: Defaults.cycleShortcutEnabled)
+
+    if let shortcut = gCycleShortcut {
+        defaults.set(shortcut.keycode, forKey: Defaults.cycleShortcutKeycode)
+        defaults.set(shortcut.modifiers.rawValue,
+                     forKey: Defaults.cycleShortcutModifiers)
+        defaults.set(shortcut.keyLabel, forKey: Defaults.cycleShortcutLabel)
+    } else {
+        // A negative keycode distinguishes an explicitly-cleared recorder
+        // from a fresh install, whose latent default remains Fn.
+        defaults.set(-1, forKey: Defaults.cycleShortcutKeycode)
+        defaults.removeObject(forKey: Defaults.cycleShortcutModifiers)
+        defaults.removeObject(forKey: Defaults.cycleShortcutLabel)
+    }
+}
 
 /// Writes the current switch count to UserDefaults if it has changed.
 ///

--- a/App/main.swift
+++ b/App/main.swift
@@ -113,11 +113,15 @@ Timer.scheduledTimer(withTimeInterval: flushInterval, repeats: true) { _ in
 
 // MARK: - Event Tap Installation
 //
-// The event tap intercepts keyDown events at the session level.
+// The event tap intercepts keyDown shortcuts and observes the other keyboard
+// event forms needed to distinguish bare Fn from an Fn-modified key press.
 // When a space-switch shortcut is detected, the original event is
 // swallowed and replaced with a synthetic DockSwipe gesture.
 
 let eventMask = CGEventMask(1 << CGEventType.keyDown.rawValue)
+              | CGEventMask(1 << CGEventType.keyUp.rawValue)
+              | CGEventMask(1 << CGEventType.flagsChanged.rawValue)
+              | CGEventMask(1 << kSystemDefinedEventType.rawValue)
 
 gTap = CGEvent.tapCreate(
     tap: .cgSessionEventTap,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -460,6 +460,8 @@ SwoopMenu (NSStatusItem, icon: "hare.fill")
        ├─ Auto-follow on ⌘⇥ toggle (checkmark, shortcut: F)
        ├─ Instant trackpad swipe toggle (checkmark, shortcut: T,
        │    icon: rectangle.and.hand.point.up.left.filled)
+       ├─ Cycle Spaces toggle (checkmark, shortcut: C,
+       │    disabled while transition speed is Normal)
        ├─ "Statistics:" section header
        ├─ Switch count + time-saved display (non-interactive)
        ├─ Version label

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -480,10 +480,10 @@ SettingsWindowController (singleton, NSWindowDelegate)
        ├─ AutoStartPaneController — Launch warning banner (orange, hidden when OK)
        │    + Launch at Login (SMAppService)
        ├─ FeaturesPaneController — two groups: Instant switch + Auto-follow +
-       │    Instant trackpad swipe toggles, configurable cycle-shortcut recorder + enable switch,
-       │    then Transition speed slider on its own (5 ticks, snapping: Normal =
-       │    native macOS animation / Fast / Faster / Fastest / right end cap =
-       │    "Instant", the default)
+       │    Instant trackpad swipe toggles, then Transition speed slider
+       │    (5 ticks, snapping: Normal = native macOS animation / Fast / Faster /
+       │    Fastest / right end cap = "Instant", the default) with the configurable
+       │    cycle-shortcut recorder + enable switch directly beneath it
        ├─ AdvancedPaneController — Instant Dock hide (writes com.apple.dock
        │    autohide-time-modifier, killall Dock) + Show menu bar icon toggle
        │    (statusItem.isVisible; when hidden, relaunching the app reopens

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Exact initialization order — getting this wrong causes subtle bugs:
 5. `gMenu = SwoopMenu()` — creates status item (hidden via `statusItem.isVisible` if so configured), loads persisted state from UserDefaults into globals
 6. Delayed `checkForUpdates()` — 5 seconds after launch (background network request)
 7. `Timer` for `flushSwitchCount()` — every 300 seconds
-8. **Event tap creation** — `CGEvent.tapCreate` → `CFMachPortCreateRunLoopSource` → `CFRunLoopAddSource`
+8. **Event tap creation** — listens for `keyDown`, `keyUp`, `flagsChanged`, and `systemDefined`; these support the configurable cycle shortcut (including bare Fn) as well as the system Space bindings, then `CFMachPortCreateRunLoopSource` → `CFRunLoopAddSource`
 9. **SwoopObserver registration** — `didActivateApplicationNotification` + `activeSpaceDidChangeNotification`
 10. **Cleanup handler** — `willTerminateNotification`: flush stats, remove observer, disable tap
 11. **Signal handlers** — SIGINT/SIGTERM → `NSApp.terminate`
@@ -57,6 +57,19 @@ The tap is re-enabled on `tapDisabledByTimeout` / `tapDisabledByUserInput` to st
 - Check `flags.intersection(kRelevantModifiers) == gModMask` — ensures *exactly* the right modifiers (no extras)
 - Match keycode against `gKeyLeft` (direction -1) or `gKeyRight` (direction +1)
 - Bounds check via `getSpaceList()` — don't switch past the first/last space
+
+The optional cycle shortcut is user-recordable in the Features pane. Ordinary
+shortcuts match exact keycode + Control/Option/Shift/Command modifiers on `keyDown`;
+their repeat and paired `keyUp` events are swallowed so the frontmost app sees
+nothing. Bare Fn is the one supported modifier-only binding: it is recognized on
+release, and any ordinary, media/system-defined, or modifier key event while Fn is
+held cancels the cycle. Repeated Fn-down events preserve that cancelled state, and
+modifiers already held when Fn goes down cancel it immediately. The shortcut moves
+to the next space on the cursor's display and wraps from the last space to the first.
+It is independent of the Instant Space switch toggle, but stands down at the Normal
+transition-speed tick like all synthetic switching. At Normal, the Features pane
+dims the recorder and toggle and shows a System Settings-style warning subtitle;
+the saved enabled state and shortcut remain unchanged and return at faster speeds.
 
 ### Feature 2: Auto-follow on Cmd+Tab (`SwoopObserver` in `AutoFollow.swift`)
 
@@ -181,6 +194,9 @@ All runtime state is module-level globals (not a singleton class). This is inten
 | `gEnabled` | `Bool` | Master on/off toggle |
 | `gInstantSwitchEnabled` | `Bool` | Feature 1 toggle |
 | `gAutoFollowEnabled` | `Bool` | Feature 2 toggle |
+| `gCycleShortcutEnabled` | `Bool` | Whether the configurable cycle shortcut is active |
+| `gCycleShortcut` | `CycleShortcut?` | Recorded cycle keycode, exact modifiers, and display label (`nil` when cleared) |
+| `gIsRecordingCycleShortcut` | `Bool` | Makes the global event tap stand down while Preferences records a replacement |
 | `gSwitchSpeed` | `Double` | Transition speed slider tick (0.0–1.0 in 0.25 steps; 0.0 = native macOS animation, 1.0 = instant) |
 | `gLastSpaceSwitchTime` | `Date` | For auto-follow suppression (initialized to `.distantPast`) |
 | `gSwitchCount` | `Int` | Lifetime switch counter (persisted periodically) |
@@ -191,7 +207,9 @@ All runtime state is module-level globals (not a singleton class). This is inten
 
 ### UserDefaults keys (`Defaults` enum)
 
-`spacerabbit.enabled`, `spacerabbit.instantSwitch`, `spacerabbit.autoFollow`, `spacerabbit.switchSpeed`, `spacerabbit.switchCount`, `spacerabbit.showMenuBarIcon`.
+`spacerabbit.enabled`, `spacerabbit.instantSwitch`, `spacerabbit.autoFollow`,
+`spacerabbit.cycleShortcut.enabled`, `.keycode`, `.modifiers`, `.label`,
+`spacerabbit.switchSpeed`, `spacerabbit.switchCount`, `spacerabbit.showMenuBarIcon`.
 
 Menu bar icon visibility has no `g` global: the live truth is `statusItem.isVisible` (`SwoopMenu.isMenuBarIconVisible`), persisted through `setMenuBarIconVisible(_:)`.
 
@@ -209,6 +227,8 @@ Persistence strategy: `flushSwitchCount()` writes to disk only if `gSwitchCount 
 | `kAutoFollowSuppressionWindow` | AutoFollow | `0.3` (TimeInterval) | Grace period before auto-follow kicks in |
 | `kCursorWarpRestoreDelay` | SpaceSwitching | `0.15` (TimeInterval) | How long the cursor stays parked on the target display after a cross-display warp switch (the Dock samples the cursor asynchronously) |
 | `kRelevantModifiers` | EventTap | Control/Cmd/Alt/Shift | Modifier keys checked when matching shortcuts |
+| `kFnKeycode` | State | `63` | Virtual keycode used for the recordable bare-Fn/Globe binding |
+| `kCycleShortcutModifiers` | State | Control/Cmd/Alt/Shift/Fn | Exact modifier set checked for recorded cycle shortcuts. The automatic function flag on special/F-keys is normalized; a physically held Fn is still rejected as an unrecorded extra except for F-key bindings, where it is allowed to support either macOS top-row mode. |
 | `kMenuIconSize` | MenuBar | `16` (CGFloat) | Tinted SF Symbol size in menu items |
 | `kDisabledIconAlpha` | MenuBar | `0.25` (CGFloat) | Menu bar icon opacity when disabled |
 | `kEnableRowHeight` / `kEnableRowInset` | MenuBar | `36` / `14` (CGFloat) | Sizing for the header row hosting the master enable switch |
@@ -255,6 +275,15 @@ Toggles can be changed from two places. The sync pattern:
 1. **Menu bar** → `SwoopMenu.toggleInstantSwitch`/`toggleAutoFollow`: writes `gXxxEnabled` → `UserDefaults` → updates menu checkmark
 2. **Settings window** → `FeaturesPaneController.toggleInstantSwitch`/`toggleAutoFollow`: writes `gXxxEnabled` → `UserDefaults` → calls `gMenu?.syncMenuItems()` to sync menu checkmarks
 3. **Settings pane appears** (`viewWillAppear`, fires on every pane swap): refreshes its switch controls from globals
+
+The cycle-shortcut row additionally uses `ShortcutRecorderButton` from
+`ShortcutRecorder.swift`: clicking it installs
+a temporary local key monitor and sets `gIsRecordingCycleShortcut` so the global tap
+passes candidates through. Escape cancels, unmodified Delete clears, bare typing keys
+require Control/Option/Command, standalone F-keys are allowed, and bare Fn is recorded
+on release. Fn used with an ordinary, modifier, or media key does not record bare Fn;
+Fn-produced F-keys are normalized to the same binding as standalone F-keys. Recording
+a shortcut enables it; clearing disables it.
 
 Master enable/disable (`gEnabled`) is only togglable from the menu bar (header-row switch or right-click on the icon; both go through `setEnabled`, which keeps the switch state in sync).
 
@@ -304,6 +333,7 @@ SettingsWindowController (singleton, NSWindowDelegate)
        ├─ AutoStartPaneController — Launch warning banner (orange, hidden when OK)
        │    + Launch at Login (SMAppService)
        ├─ FeaturesPaneController — two groups: Instant switch + Auto-follow toggles,
+       │    configurable cycle-shortcut recorder + enable switch,
        │    then Transition speed slider on its own (5 ticks, snapping: Normal =
        │    native macOS animation / Fast / Faster / Fastest / right end cap =
        │    "Instant", the default)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Space Rabbit removes animations when switching macOS Spaces. Reclaim hours of yo
 ## Features
 
 - ✅ **Instant space switch** - your keyboard shortcut switches spaces with zero animation
+- ✅ **Configurable space cycling** - assign Fn/Globe, an F-key, or a global shortcut and wrap back to the first Space
 - ✅ **Auto-follow on Cmd+Tab** - switching to an app on another space takes you there instantly
 - ✅ **Reads your shortcuts** - picks up your bindings from System Settings automatically
 - ✅ **Tiny native macOS app** - 2MB binary size, 12MB memory usage, zero CPU usage


### PR DESCRIPTION
Closes #27.

## Summary

Adds an optional global shortcut for cycling through Spaces without needing to choose a direction.

- Disabled by default, with Fn/Globe as the initial shortcut when enabled.
- Advances to the next Space on the display under the pointer.
- Wraps from the last Space back to the first.
- Provides a shortcut recorder supporting bare Fn, function keys, and modified key combinations.
- Leaves the existing left/right Space shortcuts unchanged.
- Places the setting below Transition Speed, as discussed in #27.
- Makes Cycle Spaces unavailable when Transition Speed is set to Normal. Supporting this would require a separate animated cycling implementation.
- Adds a synchronized menu-bar toggle with `⌘C`.
- Includes translations for all seven supported languages.

## Validation

- `make build`
- Localization validation: 71 keys across 7 languages

## Screenshots

<img width="321" height="322" alt="2026-08-08-DBANEidE@2x" src="https://github.com/user-attachments/assets/e22dcdaf-1f3a-4caf-822d-17f8a0e7adfc" />

<img width="646" height="320" alt="2026-08-08-m6351nod@2x" src="https://github.com/user-attachments/assets/bdccf84e-20a9-4877-9d90-922368bcde5d" />

