### PR TITLE
fix: trackpad swipe direction reversed on macOS 27 (26A5388g)

### DIFF
--- a/App/SwipeIntercept.swift
+++ b/App/SwipeIntercept.swift
@@ -482,25 +482,28 @@ func swipeTapCallback(proxy: CGEventTapProxy, type: CGEventType,
 // MARK: - Direction & Firing
 
 /// Whether the given progress/velocity sign means "move to the space on
-/// the right". The raw sign convention of REAL trackpad DockSwipe events
-/// has flipped across macOS releases (independently of the posting-side
-/// convention documented in SpaceSwitching.swift):
+/// the right".
 ///
-///   - macOS ≤ 26: positive = right
-///   - macOS 27+:  negative = right (inverted on the augmented path)
+/// Real trackpad DockSwipe events report horizontal progress/velocity with
+/// positive = right on every macOS release this app runs on. macOS 27
+/// (including build 26A5388g) inverts only the POSTING-side convention
+/// (`makeAugmentedDockEvent` in SpaceSwitching.swift): the augmented
+/// synthetic events the Dock accepts carry negative signs for rightward
+/// movement. That inversion does NOT extend to real events — assuming it
+/// does makes `isRightSwipe` read every physical swipe backwards, so a
+/// left-to-right swipe switches to the previous space (issue #40).
 ///
 /// The "Natural scrolling" setting needs no handling here: the window
 /// server already flips the reported sign when the user turns it off, so
-/// the rows above hold in both modes and the mapping from sign to space is
-/// unconditional. Correcting for the setting on top of that double-flips
-/// it — measured on macOS 26, natural scrolling OFF: a left-to-right swipe
-/// reports progress +0.045 and must move right, same rule as ON.
+/// the mapping from sign to space is unconditional. Correcting for the
+/// setting on top of that double-flips it — measured on macOS 26, natural
+/// scrolling OFF: a left-to-right swipe reports progress +0.045 and must
+/// move right, same rule as ON.
 ///
 /// - Parameter sign: A non-zero swipe progress or X velocity sample.
 /// - Returns: `true` when the swipe targets the next space to the right.
 private func isRightSwipe(_ sign: Double) -> Bool {
-    if requiresEventAugmentation() { return sign < 0 }
-    return sign > 0
+    sign > 0
 }
 
 /// Fires the instant switch replacing an intercepted swipe, mirroring the


### PR DESCRIPTION
Fixes #40

## Summary

With "Instant Trackpad Swipe" enabled, physical trackpad swipes switch Spaces in the **reversed** direction on macOS 27 build 26A5388g: swiping left-to-right goes to the previous Space. Keyboard shortcuts are unaffected.

## Root cause

`isRightSwipe` in `SwipeIntercept.swift` special-cases macOS 27+ to read real swipe progress/velocity as `negative = right`, mirroring the inverted **posting-side** convention of the augmented synthetic path (`makeAugmentedDockEvent` in `SpaceSwitching.swift`).

Those are two independent conventions, and on macOS 27 (26A5388g) they disagree:

| | ≤ macOS 26 | macOS 27 (26A5388g) |
|---|---|---|
| Real trackpad events: positive = right | ✅ | ✅ (measured, see #40) |
| Synthetic events the Dock accepts: positive = right | ✅ | ❌ (augmented path: negative = right) |

The macOS 27+ branch for real events was an unverified assumption derived from the posting-side inversion. Real DockSwipe events did not flip on 26A5388g, so every intercepted swipe was read backwards and re-posted in the wrong direction. The keyboard path only uses the posting convention (which is correct), which is why only the swipe feature was reversed — and why this was easy to miss in testing.

## Fix

Real events report `positive = right` on every supported release. Drop the augmented-path branch entirely:

```swift
private func isRightSwipe(_ sign: Double) -> Bool {
    sign > 0
}
```

## Testing

- Built from source with `make app` (swiftc -O, macOS 15.0 target)
- Installed on macOS 27.0 (26A5388g), "Instant Trackpad Swipe" on, natural scrolling on: swipe direction now matches native macOS (left-to-right = next Space)
- Keyboard switching, auto-follow, and the synthetic posting path are untouched

## Notes

- `joshuarli/iss` (the interception scheme's origin) has the same unverified macOS 27 assumption in `is_right_swipe` (`requires_event_augmentation() ? direction < 0.0 : ...`) — worth revisiting there too if this is confirmed.
- The vertical Mission Control interceptor has a similar physical-sign mapping (`pendingMissionControlDirection`); I left it alone since there's no evidence yet about vertical signs on macOS 27 — happy to follow up if it turns out to be inverted as well.
