### PR TITLE
fix: Mission Control and App Exposé swapped when Natural scrolling is off

### DIFF
--- a/App/State.swift
+++ b/App/State.swift
@@ -231,6 +231,17 @@ var gPendingMissionControlEvents: [CGEvent] = []
 /// state may already be transitioning by the time Changed reveals direction.
 var gPendingMissionControlOverviewState: DockOverviewState?
 
+/// "Natural scrolling" as it read when the claimed vertical gesture began.
+///
+/// The window server reports vertical gesture travel in the orientation this
+/// setting selects, but the Dock's own meaning for the gesture does not move
+/// with it, so the sign has to be corrected before it is trusted (see
+/// `verticalDirection(forPhysicalSign:)`). It is sampled once per gesture
+/// rather than per event: a toggle landing mid-gesture would otherwise let the
+/// reversal disagree with the opening decision and post a transition that
+/// compounds instead of undoing.
+var gMissionControlNaturalScrolling: Bool = true
+
 // MARK: - Mission Control Animation State
 
 /// A fully constructed terminal pair retained before an animated gesture

--- a/App/SwipeIntercept.swift
+++ b/App/SwipeIntercept.swift
@@ -345,14 +345,46 @@ private func finishMissionControlInterception() {
     DispatchQueue.main.async { updateSwipeTap() }
 }
 
+/// Reads "Natural scrolling" (`com.apple.swipescrolldirection`, unset meaning
+/// on) with the process-wide preference cache flushed first.
+///
+/// The flush is not optional: `CFPreferencesCopyAppValue` answers from an
+/// in-process cache that a change made by System Settings does not invalidate,
+/// so without it a user who flips the setting keeps the old gesture mapping
+/// until Space Rabbit is relaunched. Called once per gesture, never per event.
+private func naturalScrollingEnabled() -> Bool {
+    CFPreferencesSynchronize(kCFPreferencesAnyApplication,
+                             kCFPreferencesCurrentUser,
+                             kCFPreferencesCurrentHost)
+    return CFPreferencesCopyAppValue("com.apple.swipescrolldirection" as CFString,
+                                     kCFPreferencesAnyApplication) as? Bool ?? true
+}
+
 /// Converts a physical vertical travel sign into the direction to post for it.
 ///
-/// Physical vertical DockSwipes use screen-coordinate signs on macOS 26:
-/// finger-up is negative and finger-down is positive. Synthetic vertical
-/// posting uses the opposite convention, so this conversion must stay separate
-/// from `postMissionControlTransition`'s signed output.
+/// Physical vertical DockSwipes are reported in the orientation "Natural
+/// scrolling" selects: finger-up is negative while it is on (the default, and
+/// the configuration every earlier measurement was taken in), and positive
+/// while it is off. Measured on macOS 15.6.1 by swiping up in both modes —
+/// `-0.012` with it on, `+0.008` with it off.
+///
+/// The Dock's own meaning for the gesture does *not* move with the setting:
+/// macOS 15's Trackpad pane offers Mission Control only as "Swipe Up" and App
+/// Exposé only as "Swipe Down", in both modes. So the sign must be corrected
+/// back to physical travel before it is read, otherwise every user with the
+/// setting off gets Mission Control and App Exposé swapped (a swipe up opens
+/// App Exposé). This is the counterpart of the horizontal axis's `isRightSwipe`,
+/// whose separate rule is unaffected by this correction.
+///
+/// Synthetic vertical posting uses the opposite convention again, so this
+/// conversion must stay separate from `postMissionControlTransition`'s signed
+/// output.
+///
+/// - Parameter sign: A non-zero vertical progress or velocity sample.
+/// - Returns: `1` for a swipe up, `-1` for a swipe down.
 private func verticalDirection(forPhysicalSign sign: Double) -> Int {
-    sign < 0 ? 1 : -1
+    let isSwipeUp = gMissionControlNaturalScrolling ? sign < 0 : sign > 0
+    return isSwipeUp ? 1 : -1
 }
 
 /// Resolves a physical vertical sign against the overview state that was
@@ -584,6 +616,9 @@ func swipeTapCallback(proxy: CGEventTapProxy, type: CGEventType,
 
             gPendingMissionControlEvents = [beganCopy]
             gPendingMissionControlOverviewState = overviewState
+            // Sampled here so the opening decision and any later reversal of
+            // this gesture read the same orientation.
+            gMissionControlNaturalScrolling = naturalScrollingEnabled()
             return nil
         }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,13 +181,17 @@ augmented path inverted the reported sign (checked first, via
 match 27+ — mirroring iss's build-time `ISS_SWIPE_DIRECTION_REVERSED` — but users on
 those releases reported every swipe going the wrong way, so the rule is now the same
 for everything below 27.
-**"Natural scrolling" needs no handling** and reading
-`com.apple.swipescrolldirection` is a trap (PR #22, reverted): the window server
+**"Natural scrolling" needs no handling *on this axis*** and reading
+`com.apple.swipescrolldirection` here is a trap (PR #22, reverted): the window server
 already flips the reported sign when the setting is off, so the table above holds in
 both modes and any correction on top of it double-flips the result. Measured on macOS
 26 with natural scrolling OFF: a left-to-right swipe reports progress `+0.045` and must
 move right — the same rule as ON. A direction complaint is far more likely to be the
 synthetic-echo bug below than a scrolling-preference bug.
+
+Do **not** generalize that to the vertical axis, which behaves the opposite way and
+*does* need the correction — see "Instant Mission Control" below. The two axes were
+measured independently; neither result implies the other.
 
 **Synthetic-event marker (`kSyntheticGestureMarker`)** — Space Rabbit's own synthetic
 gestures post into the same session tap and would loop right back into this tap.
@@ -280,8 +284,22 @@ carry direction, the tap copies and holds Began (plus companion events) once the
 Dock state resolves to any of `.desktop` / `.missionControl` / `.appExpose`; the
 direction is settled later, from Changed progress.
 
-Real vertical trackpad input uses screen-coordinate signs on macOS 26:
-finger-up is negative, finger-down positive. That physical-input convention is
+Real vertical trackpad input is reported in the orientation **"Natural
+scrolling"** selects: finger-up is negative while it is on (the default), and
+positive while it is off. Measured on macOS 15.6.1 by swiping up in both modes —
+`-0.012` on, `+0.008` off. The Dock's meaning for the gesture does *not* move
+with the setting (macOS 15's Trackpad pane offers Mission Control only as "Swipe
+Up" and App Exposé only as "Swipe Down", in both modes), so
+`verticalDirection(forPhysicalSign:)` corrects the sign back to physical travel
+before reading it. Without that correction every user with the setting off gets
+the two overviews swapped — a swipe up opens App Exposé. The setting is sampled
+once per gesture into `gMissionControlNaturalScrolling` at Began, not per event,
+so a toggle landing mid-gesture cannot make a reversal disagree with the opening
+decision; the read flushes the CFPreferences cache first, which otherwise pins
+the old value until relaunch. This is the *opposite* of the horizontal rule —
+see the natural-scrolling note under Feature 3.
+
+That physical-input convention is
 inverted before posting, because the synthetic vertical DockSwipe reads `+1` as
 up and `-1` as down. `pendingMissionControlDirection` owns the four combinations
 that do something on screen — desktop→up enters Mission Control, desktop→down
@@ -568,6 +586,7 @@ documented at its declaration in `State.swift`.
 | `gSwipeIntentDirection` / `gSwipeIntentProgress` | `Int` / `Double` | Direction the current horizontal gesture last acted on (`0` = none, so it doubles as "already fired") and the furthest progress reached since — the reversal reference |
 | `gMissionControlSwipeTracking` / `gPendingMissionControlEvents` / `gPendingMissionControlOverviewState` | `Bool` / `[CGEvent]` / `DockOverviewState?` | Claimed vertical stream, copied prefix, and its exact desktop/Mission Control origin awaiting direction/native replay |
 | `gMissionControlIntentSign` / `gMissionControlIntentProgress` | `Int` / `Double` | Same reversal pair for the claimed vertical gesture, on the *physical* sign convention |
+| `gMissionControlNaturalScrolling` | `Bool` | "Natural scrolling" as it read at the claimed vertical gesture's Began — the orientation its progress signs must be corrected against |
 | `gMissionControlAnimation` / `gMissionControlAnimationID` | `MissionControlAnimationState?` / `UInt64` | Active timed vertical transition and generation ID; accessed only on the Mission Control animation queue |
 | `gSwitchSpeed` | `Double` | Transition speed slider tick (0.0–1.0 in 0.25 steps; 0.0 = native macOS animation, 1.0 = instant) |
 | `gLastSpaceSwitchTime` | `Date` | For auto-follow suppression (initialized to `.distantPast`). Stamped by Features 1/3 and by non-auto-follow space changes |


### PR DESCRIPTION
## The bug

With **Natural scrolling turned off**, Instant Mission Control inverts both vertical gestures: a 4-finger swipe **up** opens **App Exposé**, and a swipe **down** opens **Mission Control**. Native macOS does the opposite, so the feature fights muscle memory. Turning Natural scrolling on was the only workaround.

## Cause

Vertical trackpad progress is reported in the orientation the Natural scrolling setting selects — finger-up is negative while it's on, positive while it's off — but the Dock's meaning for the gesture does **not** move with the setting. macOS 15's Trackpad pane offers Mission Control only as "Swipe Up" and App Exposé only as "Swipe Down", in both modes:

`verticalDirection(forPhysicalSign:)` hardcoded `sign < 0 ? 1 : -1`, which is the natural-scrolling-**on** convention — the default, and the state the original macOS 26 calibration was taken in. Everyone with the setting off got the two overviews swapped.

## Measurement

Same machine, same OS, swiping up, only the setting changed:

| Natural scrolling | swipe up reports |
|---|---|
| ON | `-0.012` |
| OFF | `+0.008` |

This also rules out the more obvious hypothesis that it was a macOS 15 vs 26 difference — both signs appear on one machine.

Note this is the **opposite** of the horizontal axis, where `CLAUDE.md` documents (from PR #22, reverted) that the window server's flip cancels out and reading the preference is a trap. That note was measured on horizontal only; I've narrowed its wording to that axis rather than removing it, since the horizontal result may well still hold.

## Fix

`verticalDirection(forPhysicalSign:)` now corrects the sign back to physical travel using `com.apple.swipescrolldirection`.

Two details worth reviewing:

- **Sampled once per gesture at Began**, into `gMissionControlNaturalScrolling`, not per event. The reversal path calls the same function after the pending state is cleared, so a toggle landing mid-gesture would otherwise let a reversal *compound* the transition instead of undoing it.
- **The read flushes the CFPreferences cache first.** `CFPreferencesCopyAppValue` answers from an in-process cache that a change made in System Settings does not invalidate — without the flush, a user who flips the setting keeps the old mapping until Space Rabbit is relaunched. (This bit me while measuring.)

## Risk

Essentially nil for existing users. With Natural scrolling **on** the new expression reduces to the old one exactly, so behaviour is unchanged in the default configuration on every release, macOS 26 included. Only the off case changes, and only from broken to correct.

## Scope

Vertical axis only. `isRightSwipe` is untouched — whether the horizontal axis has the same latent issue is **unverified**, and I didn't want to claim it either way without a clean measurement.

## Tested on

- MacBook Air M2 (Mac14,2), macOS 15.6.1 (24G90)
- Natural scrolling **off** (the broken configuration), then re-verified with it **on**
- 4-finger gestures (Mission Control and App Exposé both set to four fingers)

Verified: up from desktop → Mission Control; down from desktop → App Exposé; down in Mission Control → dismisses; up in App Exposé → dismisses; mid-gesture reversal without lifting the fingers; and toggling Natural scrolling live with no relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

