### PR TITLE
fix: let auto-follow stand down after user-listed popup hotkeys

### DIFF
--- a/App/AutoFollow.swift
+++ b/App/AutoFollow.swift
@@ -48,6 +48,15 @@ private let kAutoFollowEchoWindow: TimeInterval = 0.3
 /// silently swallow the stamp for an unrelated space change much later.
 let kAutoFollowSelfChangeWindow: TimeInterval = 1.5
 
+/// How long after a key-down matching the auto-follow ignore list an app
+/// activation is attributed to that hotkey (see `gLastHotkeyChordTime`).
+///
+/// Hotkey handlers activate their app within a few tens of milliseconds
+/// of the key-down; 300ms covers scheduling delay under load while
+/// staying well below the time between pressing a hotkey and separately
+/// reaching for Cmd+Tab or the Dock.
+private let kAutoFollowIgnoredHotkeyWindow: TimeInterval = 0.3
+
 // MARK: - App Activation Observer
 
 /// Watches for `NSWorkspace.didActivateApplicationNotification` and
@@ -83,6 +92,16 @@ final class SwoopObserver: NSObject {
         // Suppress auto-follow when the user just navigated spaces themselves
         // (see kAutoFollowSuppressionWindow documentation above)
         guard Date().timeIntervalSince(gLastSpaceSwitchTime) > kAutoFollowSuppressionWindow
+        else { return }
+
+        // A hotkey from the user's ignore list just went by: this
+        // activation is that hotkey's doing — an app summoned to open a
+        // popup on the *current* space (Arc's Little Arc). The popup
+        // window does not exist yet at notification time, so
+        // findSpaceForPid would chase the app's main window on another
+        // space and yank the user away from the popup they just summoned.
+        // Stand down and let macOS's native handling take over.
+        guard Date().timeIntervalSince(gLastHotkeyChordTime) > kAutoFollowIgnoredHotkeyWindow
         else { return }
 
         // A Mission Control overview handles navigation itself and our

--- a/App/EventTap.swift
+++ b/App/EventTap.swift
@@ -241,6 +241,8 @@ func syncKeyboardAuxiliaryTaps() {
     let claimedKeyListening = gCycleShortcutActiveKeycode != nil
         || gMissionControlActiveKeycode != nil
         || gFnPressState.isDown
+        || gIsRecordingIgnoredHotkey
+        || gIgnoredRecordingClaimedKeycode != nil
 
     // Physical Fn tracking only exists to serve a configured cycle shortcut.
     let modifierListening = gCycleShortcutEnabled
@@ -274,8 +276,9 @@ private func resetFnPressTracking() {
 /// Clears all state tied to a key press Space Rabbit swallowed.
 private func resetKeyTracking() {
     resetFnPressTracking()
-    gCycleShortcutActiveKeycode  = nil
-    gMissionControlActiveKeycode = nil
+    gCycleShortcutActiveKeycode     = nil
+    gMissionControlActiveKeycode    = nil
+    gIgnoredRecordingClaimedKeycode = nil
 }
 
 /// Moves to the next space on the display under the cursor, wrapping from
@@ -423,6 +426,38 @@ func eventTapCallback(proxy: CGEventTapProxy, type: CGEventType,
         return passthrough
     }
 
+    // While Preferences records a hotkey for the auto-follow ignore list,
+    // the tap itself is the recorder. The chords being recorded are, by
+    // definition, other apps' registered global hotkeys: the system
+    // delivers them to their registrant, never to our windows, so the
+    // local-monitor recording the cycle shortcut uses would miss the event
+    // entirely — and the hotkey would fire, opening the very popup being
+    // recorded. Swallowing here keeps the other app quiet; the capture is
+    // handed to the recorder control (gIgnoredHotkeyCaptureHandler), which
+    // owns validation and cancellation. The key-up paired with a swallowed
+    // key-down is swallowed too, so no app receives an orphan release.
+    if gIsRecordingIgnoredHotkey || gIgnoredRecordingClaimedKeycode != nil {
+        let captureKeycode = event.getIntegerValueField(.keyboardEventKeycode)
+
+        if type == .keyUp {
+            guard gIgnoredRecordingClaimedKeycode == captureKeycode else { return passthrough }
+            gIgnoredRecordingClaimedKeycode = nil
+            return nil
+        }
+
+        if gIsRecordingIgnoredHotkey, type == .keyDown {
+            gIgnoredRecordingClaimedKeycode = captureKeycode
+            if let capture = event.copy() {
+                DispatchQueue.main.async { gIgnoredHotkeyCaptureHandler?(capture) }
+            }
+            return nil
+        }
+
+        // flagsChanged / systemDefined during recording carry nothing to
+        // capture and nothing to swallow.
+        return passthrough
+    }
+
     // While Preferences records a replacement shortcut, let AppKit receive
     // every candidate event without the existing global binding firing.
     if gIsRecordingCycleShortcut {
@@ -503,6 +538,21 @@ func eventTapCallback(proxy: CGEventTapProxy, type: CGEventType,
     // systemDefined is observed only for bare-Fn chord detection. Shortcut
     // matching itself applies to ordinary keyDown events.
     guard type == .keyDown else { return passthrough }
+
+    // Auto-follow's ignore list: when this key-down matches one of the
+    // user's listed popup hotkeys, stamp the time so SwoopObserver stands
+    // down for the app activation that follows — the hotkey's app is about
+    // to open a popup on the *current* space, and chasing its other
+    // windows would yank the user away from it (see gLastHotkeyChordTime).
+    // The event always passes through: the hotkey's own app must still
+    // receive it. Matching mirrors the cycle shortcut: keycode plus exact
+    // modifiers. Free when the list is empty — the default.
+    for chord in gAutoFollowIgnoredChords
+    where keycode == chord.keycode
+        && flags.intersection(chord.matchingModifierMask) == chord.modifiers {
+        gLastHotkeyChordTime = Date()
+        break
+    }
 
     // Keyboard-triggered Mission Control. Matched before the Space shortcuts
     // and independent of the Instant Space switch toggle — this is the Instant

--- a/App/MenuBar.swift
+++ b/App/MenuBar.swift
@@ -119,6 +119,7 @@ final class SwoopMenu: NSObject {
         gTrackpadSwipeEnabled    = defaults.bool(forKey: Defaults.trackpadSwipe)
         gInstantMissionControlEnabled = defaults.bool(forKey: Defaults.instantMissionControl)
         loadCycleShortcut()
+        loadAutoFollowIgnoredChords()
         let persistedSpeedObject = defaults.object(forKey: Defaults.switchSpeed)
         let persistedSwitchSpeed = (persistedSpeedObject as? NSNumber)?.doubleValue ?? 1.0
         gSwitchSpeed             = normalizedSwitchSpeed(persistedSwitchSpeed)

--- a/App/Resources/de.lproj/Localizable.strings
+++ b/App/Resources/de.lproj/Localizable.strings
@@ -92,6 +92,9 @@
 "settings.features.cycleSpaces.normalWarning" = "Nicht verfügbar bei Geschwindigkeit „Normal“";
 "settings.features.shortcut.recording" = "Kurzbefehl drücken…";
 "settings.features.shortcut.none" = "Keiner";
+"settings.features.autoFollowIgnored" = "Zu ignorierende Popup-Kurzbefehle";
+"settings.features.autoFollowIgnored.record" = "Kurzbefehl aufzeichnen…";
+"settings.features.autoFollowIgnored.remove" = "Entfernen";
 "settings.features.transitionSpeed" = "Übergangsgeschwindigkeit";
 
 /* Transition-speed slider ticks, slowest to fastest. "Normal" is macOS's own

--- a/App/Resources/en.lproj/Localizable.strings
+++ b/App/Resources/en.lproj/Localizable.strings
@@ -94,6 +94,9 @@
 "settings.features.cycleSpaces.normalWarning" = "Unavailable when speed is Normal";
 "settings.features.shortcut.recording" = "Press shortcut…";
 "settings.features.shortcut.none" = "None";
+"settings.features.autoFollowIgnored" = "Popup hotkeys to ignore";
+"settings.features.autoFollowIgnored.record" = "Record hotkey…";
+"settings.features.autoFollowIgnored.remove" = "Remove";
 "settings.features.transitionSpeed" = "Transition speed";
 
 /* Transition-speed slider ticks, slowest to fastest. "Normal" is macOS's own

--- a/App/Resources/es.lproj/Localizable.strings
+++ b/App/Resources/es.lproj/Localizable.strings
@@ -94,6 +94,9 @@
 "settings.features.cycleSpaces.normalWarning" = "No disponible si la velocidad es «Normal»";
 "settings.features.shortcut.recording" = "Pulsa una función rápida…";
 "settings.features.shortcut.none" = "Ninguna";
+"settings.features.autoFollowIgnored" = "Atajos de ventana emergente a ignorar";
+"settings.features.autoFollowIgnored.record" = "Grabar atajo…";
+"settings.features.autoFollowIgnored.remove" = "Eliminar";
 "settings.features.transitionSpeed" = "Velocidad de transición";
 
 /* Transition-speed slider ticks, slowest to fastest. "Normal" is macOS's own

--- a/App/Resources/fr.lproj/Localizable.strings
+++ b/App/Resources/fr.lproj/Localizable.strings
@@ -96,6 +96,9 @@
 "settings.features.cycleSpaces.normalWarning" = "Indisponible si la vitesse est «\U00A0Normale\U00A0»";
 "settings.features.shortcut.recording" = "Appuyez sur un raccourci…";
 "settings.features.shortcut.none" = "Aucun";
+"settings.features.autoFollowIgnored" = "Raccourcis de popups à ignorer";
+"settings.features.autoFollowIgnored.record" = "Enregistrer le raccourci…";
+"settings.features.autoFollowIgnored.remove" = "Supprimer";
 "settings.features.transitionSpeed" = "Vitesse de transition";
 
 /* Transition-speed slider ticks, slowest to fastest. "Normal" is macOS's own

--- a/App/Resources/pt.lproj/Localizable.strings
+++ b/App/Resources/pt.lproj/Localizable.strings
@@ -95,6 +95,9 @@
 "settings.features.cycleSpaces.normalWarning" = "Indisponível se a velocidade for “Normal”";
 "settings.features.shortcut.recording" = "Pressione um atalho…";
 "settings.features.shortcut.none" = "Nenhum";
+"settings.features.autoFollowIgnored" = "Atalhos de popups a ignorar";
+"settings.features.autoFollowIgnored.record" = "Gravar atalho…";
+"settings.features.autoFollowIgnored.remove" = "Remover";
 "settings.features.transitionSpeed" = "Velocidade da transição";
 
 /* Transition-speed slider ticks, slowest to fastest. "Normal" is macOS's own

--- a/App/Resources/ru.lproj/Localizable.strings
+++ b/App/Resources/ru.lproj/Localizable.strings
@@ -97,6 +97,9 @@
 "settings.features.cycleSpaces.normalWarning" = "Недоступно при скорости «Обычная»";
 "settings.features.shortcut.recording" = "Нажмите сочетание…";
 "settings.features.shortcut.none" = "Нет";
+"settings.features.autoFollowIgnored" = "Игнорируемые сочетания всплывающих окон";
+"settings.features.autoFollowIgnored.record" = "Записать сочетание…";
+"settings.features.autoFollowIgnored.remove" = "Удалить";
 "settings.features.transitionSpeed" = "Скорость перехода";
 
 /* Transition-speed slider ticks, slowest to fastest. "Normal" is macOS's own

--- a/App/Resources/zh-Hans.lproj/Localizable.strings
+++ b/App/Resources/zh-Hans.lproj/Localizable.strings
@@ -97,6 +97,9 @@
 "settings.features.cycleSpaces.normalWarning" = "速度为“正常”时不可用";
 "settings.features.shortcut.recording" = "按下快捷键…";
 "settings.features.shortcut.none" = "无";
+"settings.features.autoFollowIgnored" = "要忽略的弹窗快捷键";
+"settings.features.autoFollowIgnored.record" = "录制快捷键…";
+"settings.features.autoFollowIgnored.remove" = "移除";
 "settings.features.transitionSpeed" = "过渡速度";
 
 /* Transition-speed slider ticks, slowest to fastest. "Normal" is macOS's own

--- a/App/Settings.swift
+++ b/App/Settings.swift
@@ -992,6 +992,8 @@ final class FeaturesPaneController: SettingsPaneViewController {
     private var cycleShortcutControl:  NSSwitch!
     private var shortcutRecorder:      ShortcutRecorderButton!
     private var cycleShortcutRow:      SettingsRowView!
+    private var ignoredHotkeysRecorder: ShortcutRecorderButton!
+    private var ignoredHotkeysStack:    NSStackView!
     private var speedSlider:           NSSlider!
     private var speedValueLabel:       NSTextField!
     private var speedBoltIcon:         NSImageView!
@@ -1052,12 +1054,43 @@ final class FeaturesPaneController: SettingsPaneViewController {
         // The cycle shortcut is purely optional, so it stands on its own
         // rather than reading as part of either neighbouring group
         let cycleGroup = groupBox([cycleShortcutRow])
+
+        // Auto-follow's ignore list: popup hotkeys the user records here
+        // are stamped by the event tap so auto-follow stands down for the
+        // activation they cause (see gAutoFollowIgnoredChords). The
+        // recorder doubles as the "add" control; each recorded hotkey
+        // becomes a removable row below it.
+        ignoredHotkeysRecorder = ShortcutRecorderButton(
+            shortcut: nil,
+            recordingTitle: L("settings.features.shortcut.recording"),
+            emptyTitle: L("settings.features.autoFollowIgnored.record"),
+            capturesGlobally: true
+        )
+        ignoredHotkeysRecorder.onChange = { [weak self] shortcut in
+            self?.ignoredHotkeyRecorded(shortcut)
+        }
+        ignoredHotkeysRecorder.widthAnchor.constraint(
+            greaterThanOrEqualToConstant: Layout.shortcutMinWidth
+        ).isActive = true
+
+        ignoredHotkeysStack = NSStackView()
+        ignoredHotkeysStack.orientation = .vertical
+        ignoredHotkeysStack.alignment   = .width
+        ignoredHotkeysStack.spacing     = 0
+
+        let ignoredGroup = groupBox([
+            settingsRow(label: L("settings.features.autoFollowIgnored"),
+                        control: ignoredHotkeysRecorder),
+            ignoredHotkeysStack,
+        ])
+        rebuildIgnoredHotkeyRows(resize: false)
+
         let speedGroup = groupBox([
             settingsRow(label: L("settings.features.transitionSpeed"),
                         control: makeSpeedControl()),
         ])
         updateCycleShortcutAvailability()
-        return [togglesGroup, cycleGroup, speedGroup]
+        return [togglesGroup, ignoredGroup, cycleGroup, speedGroup]
     }
 
     override func syncFromGlobals() {
@@ -1069,9 +1102,65 @@ final class FeaturesPaneController: SettingsPaneViewController {
         missionControlControl.state   = gInstantMissionControlEnabled ? .on : .off
         cycleShortcutControl.state    = gCycleShortcutEnabled    ? .on : .off
         shortcutRecorder.setShortcut(gCycleShortcut)
+        rebuildIgnoredHotkeyRows()
         speedSlider.doubleValue       = gSwitchSpeed
         updateSpeedDisplay()
         updateCycleShortcutAvailability()
+    }
+
+    /// Rebuilds the removable per-hotkey rows of the auto-follow ignore
+    /// list, one row per recorded chord, each preceded by a divider.
+    private func rebuildIgnoredHotkeyRows(resize: Bool = true) {
+        ignoredHotkeysStack.arrangedSubviews.forEach {
+            ignoredHotkeysStack.removeArrangedSubview($0)
+            $0.removeFromSuperview()
+        }
+        for (index, chord) in gAutoFollowIgnoredChords.enumerated() {
+            let remove = NSButton(
+                image: NSImage(systemSymbolName: "minus.circle.fill",
+                               accessibilityDescription:
+                                   L("settings.features.autoFollowIgnored.remove"))!,
+                target: self,
+                action: #selector(removeIgnoredHotkey(_:))
+            )
+            remove.isBordered = false
+            remove.contentTintColor = .secondaryLabelColor
+            remove.toolTip = L("settings.features.autoFollowIgnored.remove")
+            remove.tag = index
+
+            ignoredHotkeysStack.addArrangedSubview(rowDivider())
+            ignoredHotkeysStack.addArrangedSubview(
+                settingsRow(label: chord.displayString, control: remove)
+            )
+        }
+        if resize { resizePaneToFit() }
+    }
+
+    /// A newly recorded hotkey for the ignore list. Bare Fn cannot work
+    /// here — its press is a `flagsChanged`, invisible to the key-down
+    /// match — and duplicates add nothing; both are refused with a beep.
+    /// The recorder itself is reset either way: it is an "add" button,
+    /// not a display of any one binding.
+    private func ignoredHotkeyRecorded(_ shortcut: CycleShortcut?) {
+        ignoredHotkeysRecorder.setShortcut(nil)
+        guard let shortcut, !shortcut.isBareFn,
+              !gAutoFollowIgnoredChords.contains(where: {
+                  $0.keycode == shortcut.keycode && $0.modifiers == shortcut.modifiers
+              })
+        else {
+            if shortcut != nil { NSSound.beep() }
+            return
+        }
+        gAutoFollowIgnoredChords.append(shortcut)
+        persistAutoFollowIgnoredChords()
+        rebuildIgnoredHotkeyRows()
+    }
+
+    @objc private func removeIgnoredHotkey(_ sender: NSButton) {
+        guard gAutoFollowIgnoredChords.indices.contains(sender.tag) else { return }
+        gAutoFollowIgnoredChords.remove(at: sender.tag)
+        persistAutoFollowIgnoredChords()
+        rebuildIgnoredHotkeyRows()
     }
 
     /// Builds the transition-speed control: a 5-tick slider with a trailing

--- a/App/ShortcutRecorder.swift
+++ b/App/ShortcutRecorder.swift
@@ -23,6 +23,12 @@ final class ShortcutRecorderButton: NSButton {
     private var shortcut: CycleShortcut?
     private let recordingTitle: String
     private let emptyTitle: String
+    /// When `true`, recording is performed by the global event tap rather
+    /// than a local monitor — required for the auto-follow ignore list,
+    /// whose chords are other apps' live global hotkeys: a local monitor
+    /// would never receive them, and the press would fire the very popup
+    /// being recorded (see `gIsRecordingIgnoredHotkey`).
+    private let capturesGlobally: Bool
     private var localMonitor: Any?
     private var recordingObservers: [NSObjectProtocol] = []
     private var isRecording = false
@@ -30,10 +36,12 @@ final class ShortcutRecorderButton: NSButton {
 
     override var acceptsFirstResponder: Bool { true }
 
-    init(shortcut: CycleShortcut?, recordingTitle: String, emptyTitle: String) {
+    init(shortcut: CycleShortcut?, recordingTitle: String, emptyTitle: String,
+         capturesGlobally: Bool = false) {
         self.shortcut = shortcut
         self.recordingTitle = recordingTitle
         self.emptyTitle = emptyTitle
+        self.capturesGlobally = capturesGlobally
         super.init(frame: .zero)
 
         bezelStyle  = .rounded
@@ -63,17 +71,26 @@ final class ShortcutRecorderButton: NSButton {
 
         isRecording = true
         recordingFnState.reset()
-        gIsRecordingCycleShortcut = true
+        if capturesGlobally {
+            gIsRecordingIgnoredHotkey = true
+            gIgnoredHotkeyCaptureHandler = { [weak self] event in
+                self?.handleGlobalCapture(event)
+            }
+        } else {
+            gIsRecordingCycleShortcut = true
+        }
         syncKeyboardAuxiliaryTaps()
         title = recordingTitle
         window?.makeFirstResponder(self)
 
-        localMonitor = NSEvent.addLocalMonitorForEvents(
-            matching: [.keyDown, .flagsChanged, .systemDefined]
-        ) { [weak self] event in
-            guard let self, self.isRecording else { return event }
-            self.handleRecordingEvent(event)
-            return nil
+        if !capturesGlobally {
+            localMonitor = NSEvent.addLocalMonitorForEvents(
+                matching: [.keyDown, .flagsChanged, .systemDefined]
+            ) { [weak self] event in
+                guard let self, self.isRecording else { return event }
+                self.handleRecordingEvent(event)
+                return nil
+            }
         }
 
         let center = NotificationCenter.default
@@ -154,6 +171,41 @@ final class ShortcutRecorderButton: NSButton {
         commit(CycleShortcut(keycode: keycode, modifiers: modifiers, keyLabel: label))
     }
 
+    /// Handles one key-down captured by the event tap while recording for
+    /// the auto-follow ignore list (see `gIsRecordingIgnoredHotkey`). The
+    /// tap has already swallowed the event, so the hotkey's own app stays
+    /// quiet. Validation mirrors `handleRecordingEvent` minus the Fn
+    /// special cases, which cannot occur here — bare Fn arrives as a
+    /// `flagsChanged` and is never captured.
+    private func handleGlobalCapture(_ cgEvent: CGEvent) {
+        guard isRecording, let event = NSEvent(cgEvent: cgEvent) else { return }
+
+        let keycode = Int64(event.keyCode)
+        let modifiers = cycleModifiers(from: event.modifierFlags)
+
+        // Escape cancels; an unmodified Delete commits nothing — both
+        // leave recording mode, exactly like the local path.
+        if keycode == kEscapeKeycode, modifiers.isEmpty {
+            cancelRecording()
+            return
+        }
+        if keycode == kDeleteKeycode || keycode == kForwardDeleteKeycode,
+           modifiers.isEmpty {
+            commit(nil)
+            return
+        }
+
+        guard let (label, isFunctionKey) = keyLabel(for: event),
+              isFunctionKey || !modifiers.intersection(
+                  [.maskControl, .maskAlternate, .maskCommand]).isEmpty
+        else {
+            NSSound.beep()
+            return
+        }
+
+        commit(CycleShortcut(keycode: keycode, modifiers: modifiers, keyLabel: label))
+    }
+
     /// Recognizes Fn by itself while leaving other modifier-only presses
     /// available as part of a later regular-key shortcut.
     private func handleModifierChange(_ event: NSEvent) {
@@ -221,7 +273,12 @@ final class ShortcutRecorderButton: NSButton {
         recordingObservers.removeAll()
         isRecording = false
         recordingFnState.reset()
-        gIsRecordingCycleShortcut = false
+        if capturesGlobally {
+            gIsRecordingIgnoredHotkey = false
+            gIgnoredHotkeyCaptureHandler = nil
+        } else {
+            gIsRecordingCycleShortcut = false
+        }
         syncKeyboardAuxiliaryTaps()
         updateTitle()
     }

--- a/App/State.swift
+++ b/App/State.swift
@@ -161,6 +161,18 @@ func normalizedSwitchSpeed(_ value: Double) -> Double {
 /// window on yet another space.
 var gLastSpaceSwitchTime: Date = .distantPast
 
+/// Timestamp of the last key-down matching the auto-follow ignore list
+/// (`gAutoFollowIgnoredChords`), or `.distantPast`.
+///
+/// Auto-follow stands down for the app activation that follows one of the
+/// listed hotkeys: the hotkey's app is about to open a popup on the
+/// *current* space, and the popup window does not exist yet when the
+/// activation notification arrives — chasing the app's other windows
+/// would yank the user away from the popup they just summoned. Stamped
+/// by the keyboard event tap (EventTap.swift), read by `SwoopObserver`
+/// (AutoFollow.swift).
+var gLastHotkeyChordTime: Date = .distantPast
+
 /// Process ID of the app auto-follow last chased to another space, or `-1`
 /// when no follow is pending an echo. Cleared as soon as a *different* app
 /// activates, so it only ever suppresses back-to-back notifications for the
@@ -420,6 +432,34 @@ var gCycleShortcut: CycleShortcut? = .fn
 /// tap passes keyboard events through so the field can receive them locally.
 var gIsRecordingCycleShortcut = false
 
+/// True while the Preferences ignore-list recorder is armed. Unlike the
+/// cycle-shortcut recorder — whose local monitor sees events delivered to
+/// our own windows — this recording is performed by the event tap itself,
+/// because the chords being recorded are other apps' registered global
+/// hotkeys and never reach this app through normal dispatch. While set,
+/// the tap swallows every key-down and hands it to
+/// `gIgnoredHotkeyCaptureHandler` instead (EventTap.swift).
+var gIsRecordingIgnoredHotkey = false
+
+/// Receives each key-down the tap captures while
+/// `gIsRecordingIgnoredHotkey` is set, dispatched on the main queue.
+/// Installed by the recording control (ShortcutRecorder.swift), which owns
+/// validation and cancellation.
+var gIgnoredHotkeyCaptureHandler: ((CGEvent) -> Void)?
+
+/// Keycode of a key-down swallowed by ignore-list recording whose key-up
+/// is still owed a swallow, or `nil`.
+var gIgnoredRecordingClaimedKeycode: Int64?
+
+/// Global hotkeys after which auto-follow must stand down, as recorded by
+/// the user in Settings > Features. These are hotkeys that summon an app's
+/// popup onto the *current* space — Arc's Little Arc, iTerm2's hotkey
+/// window — where chasing the app's other windows would be wrong (see
+/// `gLastHotkeyChordTime`). Empty by default, so auto-follow behaves
+/// exactly as before until the user lists something. Persisted under
+/// `Defaults.autoFollowIgnoredHotkeys`.
+var gAutoFollowIgnoredChords: [CycleShortcut] = []
+
 /// Binding for "move left a space" (default: Control + Left Arrow).
 /// `nil` when the hotkey is disabled in System Settings.
 var gBindingLeft: KeyBinding? = (keycode: 123, mods: .maskControl)
@@ -464,6 +504,9 @@ enum Defaults {
     static let cycleShortcutKeycode   = "spacerabbit.cycleShortcut.keycode"
     static let cycleShortcutModifiers = "spacerabbit.cycleShortcut.modifiers"
     static let cycleShortcutLabel     = "spacerabbit.cycleShortcut.label"
+    /// Array of dictionaries (`keycode`, `modifiers`, `label`) — the
+    /// auto-follow ignore list (see `gAutoFollowIgnoredChords`).
+    static let autoFollowIgnoredHotkeys = "spacerabbit.autoFollowIgnoredHotkeys"
     static let switchSpeed      = "spacerabbit.switchSpeed"
     static let switchCount      = "spacerabbit.switchCount"
     /// When `false`, the rabbit icon is removed from the menu bar.
@@ -481,6 +524,35 @@ enum Defaults {
 }
 
 // MARK: - Persistence
+
+/// Reads the auto-follow ignore list into `gAutoFollowIgnoredChords`.
+/// Counterpart of `persistAutoFollowIgnoredChords()`. Malformed entries
+/// are skipped rather than discarding the whole list.
+func loadAutoFollowIgnoredChords() {
+    let stored = UserDefaults.standard.array(forKey: Defaults.autoFollowIgnoredHotkeys)
+        as? [[String: Any]] ?? []
+    gAutoFollowIgnoredChords = stored.compactMap { entry in
+        guard let keycode = (entry["keycode"]   as? NSNumber)?.int64Value,
+              let raw     = (entry["modifiers"] as? NSNumber)?.uint64Value,
+              let label   = entry["label"]      as? String
+        else { return nil }
+        return CycleShortcut(keycode: keycode,
+                             modifiers: CGEventFlags(rawValue: raw),
+                             keyLabel: label)
+    }
+}
+
+/// Writes the auto-follow ignore list.
+func persistAutoFollowIgnoredChords() {
+    UserDefaults.standard.set(
+        gAutoFollowIgnoredChords.map { [
+            "keycode":   NSNumber(value: $0.keycode),
+            "modifiers": NSNumber(value: $0.modifiers.rawValue),
+            "label":     $0.keyLabel,
+        ] },
+        forKey: Defaults.autoFollowIgnoredHotkeys
+    )
+}
 
 /// Reads the configurable cycle shortcut and its enabled state into the
 /// globals. Counterpart of `persistCycleShortcut()` — the negative keycode


### PR DESCRIPTION
Fixes #52 (Little Arc popup yanked across spaces).

## Problem

A global-hotkey summon (observed: Arc's Little Arc on ⌥⌘N) activates the app *before* it creates its popup window. Auto-follow's activation handler runs in that gap: `findSpaceForPid()` sees only the app's main window on another space and chases it — yanking the user away from the popup they just summoned. I'd expect the same race for other hotkey-summoned popups (iTerm2's hotkey window, 1Password Quick Access, …), though Arc is the case I observed and tested.

## Approach

Settings > Features gains a **"Popup hotkeys to ignore"** list — `ShortcutRecorderButton` reused as the add control, one removable row per recorded hotkey. The always-on keyDown tap stamps `gLastHotkeyChordTime` when a listed chord goes by (the event still passes through: the hotkey's own app must receive it), and `SwoopObserver` stands down when an activation arrives within 300 ms of the stamp (constant documented alongside the existing suppression windows).

**With the list empty — the default — behavior is exactly today's.** And for a listed hotkey, standing down simply hands the activation to macOS's native handling, the same thing users get at the "Normal" speed setting. No new failure mode in either direction.

## Cost

Empty list (the default): an empty-loop check per keyDown, nothing more. With entries: a scan of a tiny array per keyDown. The UI adds ~90 lines to the Features pane and 3 localization keys across the 7 languages — translations included, native speakers please correct freely.

## Tested

macOS 26 (Apple Silicon), running as my daily build with ⌥⌘N listed: Little Arc opens in place over the current space; ⌘Tab auto-follow still hops instantly; rcmd (an app switcher on right-⌘ chords) still auto-follows instantly — nothing listed for either. Recording ⌥⌘N with Arc running captures the chord without opening Little Arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
